### PR TITLE
feat: add self-hosted server creator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ Thumbs.db
 # Bot runtime data (guild registry)
 data/
 
+# Local implementation plans
+plans/
+
 # Logs
 *.log

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@memeover/app",
 	"private": true,
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
@@ -19,6 +19,7 @@
 		"@tanstack/react-router": "^1.170.10",
 		"@tauri-apps/api": "^2.11.0",
 		"@tauri-apps/plugin-autostart": "^2.5.1",
+		"@tauri-apps/plugin-dialog": "^2.7.1",
 		"@tauri-apps/plugin-opener": "^2.5.4",
 		"@tauri-apps/plugin-process": "^2.3.1",
 		"@tauri-apps/plugin-store": "^2.4.3",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -234,6 +234,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +459,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -474,6 +498,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +513,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1087,6 +1126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,8 +1331,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1297,9 +1344,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1925,6 +1974,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,15 +2144,17 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memeover"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "objc2",
  "raw-window-handle",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -2699,6 +2766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2862,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,6 +2937,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2912,6 +3073,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2929,6 +3091,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2979,6 +3165,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3005,6 +3192,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3041,6 +3229,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3778,6 +3967,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4693,6 +4924,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5527,6 +5768,26 @@ dependencies = [
  "serde",
  "winnow 1.0.3",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memeover"
-version = "1.3.0"
+version = "1.4.0"
 description = "An overlay application that lets friends send memes to each other in real time from a Discord text channel."
 authors = ["you"]
 edition = "2021"
@@ -25,6 +25,9 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-dialog = "2"
+# Already in the tree via tauri-plugin-updater (rustls); used for public IP detection.
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 raw-window-handle = "0.6"

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "dialog:default",
     "store:default",
     "core:event:default",
     "core:window:allow-show",

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ use tauri::{
     Emitter, Manager, WebviewUrl, WebviewWindowBuilder,
 };
 
+mod server_creator;
+
 // ─── Tray state ───────────────────────────────────────────────────────────────
 
 /// Holds handles to translatable tray menu items so the frontend can
@@ -79,7 +81,15 @@ fn apply_windows_topmost(win: &tauri::WebviewWindow) {
     // Construct the typed HWND from the raw isize value.
     let hwnd = HWND(w32.hwnd.get() as *mut core::ffi::c_void);
     unsafe {
-        let _ = SetWindowPos(hwnd, Some(HWND_TOPMOST), 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        let _ = SetWindowPos(
+            hwnd,
+            Some(HWND_TOPMOST),
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+        );
     }
 }
 
@@ -180,7 +190,8 @@ fn ensure_overlay_visible(app: tauri::AppHandle) -> Result<(), String> {
             // Re-apply the native window level before reloading so it is set
             // when the page finishes loading (main-overlay.tsx then calls show()).
             apply_native_overlay_level(&win);
-            win.eval("window.location.reload()").map_err(|e| e.to_string())?;
+            win.eval("window.location.reload()")
+                .map_err(|e| e.to_string())?;
         }
         None => {
             // Safety fallback: window was unexpectedly destroyed — recreate it.
@@ -214,9 +225,13 @@ fn move_overlay_to_monitor(app: tauri::AppHandle, monitor_index: usize) -> Resul
         .ok_or_else(|| "Overlay window not found".to_string())?;
 
     let monitors = app.available_monitors().map_err(|e| e.to_string())?;
-    let monitor = monitors
-        .get(monitor_index)
-        .ok_or_else(|| format!("Monitor index {} out of range (found {})", monitor_index, monitors.len()))?;
+    let monitor = monitors.get(monitor_index).ok_or_else(|| {
+        format!(
+            "Monitor index {} out of range (found {})",
+            monitor_index,
+            monitors.len()
+        )
+    })?;
 
     let pos = *monitor.position();
 
@@ -268,9 +283,11 @@ fn toggle_overlay_preview_mode(app: tauri::AppHandle, enabled: bool) -> Result<(
         win.maximize().map_err(|e| e.to_string())?;
         win.set_background_color(Some(tauri::utils::config::Color(0, 0, 0, 0)))
             .map_err(|e| e.to_string())?;
-        win.set_ignore_cursor_events(true).map_err(|e| e.to_string())?;
+        win.set_ignore_cursor_events(true)
+            .map_err(|e| e.to_string())?;
     } else {
-        win.set_ignore_cursor_events(false).map_err(|e| e.to_string())?;
+        win.set_ignore_cursor_events(false)
+            .map_err(|e| e.to_string())?;
         win.set_background_color(None).map_err(|e| e.to_string())?;
         win.unmaximize().map_err(|e| e.to_string())?;
         win.set_always_on_top(false).map_err(|e| e.to_string())?;
@@ -465,6 +482,8 @@ fn setup_settings_close_behavior(app: &tauri::App) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .manage(server_creator::ServerCreatorState::default())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
@@ -488,6 +507,14 @@ pub fn run() {
             update_tray_labels,
             toggle_overlay_preview_mode,
             move_overlay_to_monitor,
+            server_creator::server_creator_status,
+            server_creator::server_creator_install,
+            server_creator::server_creator_install_bun,
+            server_creator::server_creator_start,
+            server_creator::server_creator_stop,
+            server_creator::server_creator_restart,
+            server_creator::server_creator_logs,
+            server_creator::server_creator_public_ip,
         ])
         .setup(|app| {
             create_overlay_window(&app.handle().clone())?;
@@ -510,6 +537,15 @@ pub fn run() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .build(tauri::generate_context!())
         .expect("error while running tauri application")
+        .run(|app_handle, event| {
+            // Kill the managed self-hosted bot process so it does not
+            // outlive the app and keep its port bound.
+            if let tauri::RunEvent::Exit = event {
+                server_creator::shutdown(
+                    &app_handle.state::<server_creator::ServerCreatorState>(),
+                );
+            }
+        })
 }

--- a/app/src-tauri/src/server_creator.rs
+++ b/app/src-tauri/src/server_creator.rs
@@ -685,3 +685,59 @@ pub async fn server_creator_public_ip(
     }
     Err("Could not detect public IP automatically".to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "memeover-server-creator-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn server_creator_redacts_discord_token_shapes() {
+        let fake_token = "aaaaaaaaaaaaaaaaaaaaaaaa.bbbbbb.ccccccccccccccccccccccccccccccc";
+        let redacted = redact_secrets(&format!("Starting with token {fake_token}"));
+
+        assert!(redacted.contains("[redacted]"));
+        assert!(!redacted.contains(fake_token));
+    }
+
+    #[test]
+    fn server_creator_redacts_token_key_value() {
+        let redacted = redact_secrets("connected token=synthetic-secret ok");
+
+        assert_eq!(redacted, "connected [redacted] ok");
+    }
+
+    #[test]
+    fn server_creator_write_env_creates_bot_env_file() {
+        let root = unique_temp_root("write-env");
+        let req = ServerInstallRequest {
+            install_dir: root.to_string_lossy().to_string(),
+            discord_token: "synthetic-token".to_string(),
+            discord_client_id: "123456789012345678".to_string(),
+            ws_port: 3001,
+            public_ws_url: "wss://example.test/ws".to_string(),
+            repair: false,
+        };
+
+        write_env(&root, &req).expect("env file should be written");
+
+        let content = fs::read_to_string(env_path(&root)).expect("env file should be readable");
+        assert_eq!(
+            content,
+            "DISCORD_TOKEN=synthetic-token\nDISCORD_CLIENT_ID=123456789012345678\nWS_PORT=3001\nPUBLIC_WS_URL=wss://example.test/ws\n"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+}

--- a/app/src-tauri/src/server_creator.rs
+++ b/app/src-tauri/src/server_creator.rs
@@ -15,6 +15,9 @@ use tauri::{AppHandle, Manager};
 
 const REPO_URL: &str = "https://github.com/SimonHazard/MemeOver";
 const LOG_LIMIT: usize = 500;
+const INSTALL_METADATA_FILE: &str = ".memeover-server-creator.json";
+const INSTALL_METADATA_MANAGED_BY: &str = "memeover-server-creator";
+const UNMANAGED_INSTALL_ERROR: &str = "Install folder is not managed by MemeOver. Choose an empty folder or reinstall into the default folder.";
 
 /// Cloneable so commands can move an owned handle into `spawn_blocking`;
 /// the `Arc`s keep every clone pointing at the same child + log buffer.
@@ -60,6 +63,13 @@ pub struct ServerInstallResult {
     install_dir: String,
     local_ws_url: String,
     public_ws_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct InstallMetadata {
+    managed_by: String,
+    repo_url: String,
 }
 
 /// All child processes must go through this constructor: on Windows a
@@ -157,6 +167,45 @@ fn env_path(root: &Path) -> PathBuf {
 
 fn package_json_path(root: &Path) -> PathBuf {
     bot_dir(root).join("package.json")
+}
+
+fn install_metadata_path(root: &Path) -> PathBuf {
+    root.join(INSTALL_METADATA_FILE)
+}
+
+fn expected_install_metadata() -> InstallMetadata {
+    InstallMetadata {
+        managed_by: INSTALL_METADATA_MANAGED_BY.to_string(),
+        repo_url: REPO_URL.to_string(),
+    }
+}
+
+fn write_install_metadata(root: &Path) -> Result<(), String> {
+    fs::create_dir_all(root).map_err(|e| e.to_string())?;
+    let content =
+        serde_json::to_string_pretty(&expected_install_metadata()).map_err(|e| e.to_string())?;
+    fs::write(install_metadata_path(root), format!("{content}\n")).map_err(|e| e.to_string())
+}
+
+fn read_install_metadata(root: &Path) -> Result<InstallMetadata, String> {
+    let content = fs::read_to_string(install_metadata_path(root)).map_err(|e| e.to_string())?;
+    serde_json::from_str(&content).map_err(|e| e.to_string())
+}
+
+fn is_managed_install(root: &Path) -> bool {
+    read_install_metadata(root)
+        .map(|metadata| metadata == expected_install_metadata())
+        .unwrap_or(false)
+}
+
+fn ensure_managed_install(root: &Path) -> Result<(), String> {
+    if is_managed_install(root) {
+        return Ok(());
+    }
+    if package_json_path(root).exists() {
+        return Err(UNMANAGED_INSTALL_ERROR.to_string());
+    }
+    Err("Server is not installed yet".to_string())
 }
 
 fn command_exists(cmd: &str) -> bool {
@@ -359,11 +408,15 @@ fn install_sync(
 
     let source = source_dir(&root);
     let bot = bot_dir(&root);
+    let has_package_json = package_json_path(&root).exists();
+    if has_package_json {
+        ensure_managed_install(&root)?;
+    }
     let bun = bun_command().ok_or_else(|| "Bun is not installed yet".to_string())?;
 
     fs::create_dir_all(&root).map_err(|e| e.to_string())?;
 
-    if !package_json_path(&root).exists() {
+    if !has_package_json {
         if source.exists() {
             return Err(
                 "Install folder already contains a MemeOver folder but no bot package".into(),
@@ -379,6 +432,7 @@ fn install_sync(
             &["clone", "--depth=1", REPO_URL, &clone_dest],
             Some(&root),
         )?;
+        write_install_metadata(&root)?;
     } else if req.repair && source.join(".git").exists() {
         run_logged(state, "git", &["pull", "--ff-only"], Some(&source))?;
     } else {
@@ -507,9 +561,10 @@ fn start_sync(
 
     let root = normalize_install_dir(app, install_dir)?;
     let bot = bot_dir(&root);
-    if !bot.join("package.json").exists() {
+    if !package_json_path(&root).exists() {
         return Err("Server is not installed yet".to_string());
     }
+    ensure_managed_install(&root)?;
     let bun = bun_command().ok_or_else(|| "Bun is not installed yet".to_string())?;
 
     // Run the entry file directly instead of `bun run start`: the start
@@ -702,6 +757,12 @@ mod tests {
         ))
     }
 
+    fn create_synthetic_package_json(root: &Path) {
+        fs::create_dir_all(bot_dir(root)).expect("bot directory should be created");
+        fs::write(package_json_path(root), "{\"name\":\"@memeover/bot\"}\n")
+            .expect("package json should be written");
+    }
+
     #[test]
     fn server_creator_redacts_discord_token_shapes() {
         let fake_token = "aaaaaaaaaaaaaaaaaaaaaaaa.bbbbbb.ccccccccccccccccccccccccccccccc";
@@ -737,6 +798,68 @@ mod tests {
             content,
             "DISCORD_TOKEN=synthetic-token\nDISCORD_CLIENT_ID=123456789012345678\nWS_PORT=3001\nPUBLIC_WS_URL=wss://example.test/ws\n"
         );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn server_creator_install_metadata_round_trips_expected_marker() {
+        let root = unique_temp_root("metadata-round-trip");
+
+        write_install_metadata(&root).expect("metadata should be written");
+
+        assert_eq!(
+            read_install_metadata(&root).expect("metadata should be readable"),
+            InstallMetadata {
+                managed_by: INSTALL_METADATA_MANAGED_BY.to_string(),
+                repo_url: REPO_URL.to_string(),
+            }
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn server_creator_rejects_package_without_metadata() {
+        let root = unique_temp_root("metadata-missing");
+        create_synthetic_package_json(&root);
+
+        let error = ensure_managed_install(&root).expect_err("missing metadata should be rejected");
+
+        assert_eq!(error, UNMANAGED_INSTALL_ERROR);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn server_creator_rejects_wrong_repo_metadata() {
+        let root = unique_temp_root("metadata-wrong-repo");
+        create_synthetic_package_json(&root);
+        let metadata = InstallMetadata {
+            managed_by: INSTALL_METADATA_MANAGED_BY.to_string(),
+            repo_url: "https://example.test/not-memeover".to_string(),
+        };
+        fs::write(
+            install_metadata_path(&root),
+            serde_json::to_string_pretty(&metadata).expect("metadata should serialize"),
+        )
+        .expect("metadata should be written");
+
+        let error =
+            ensure_managed_install(&root).expect_err("wrong repo metadata should be rejected");
+
+        assert_eq!(error, UNMANAGED_INSTALL_ERROR);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn server_creator_accepts_valid_metadata() {
+        let root = unique_temp_root("metadata-valid");
+        create_synthetic_package_json(&root);
+        write_install_metadata(&root).expect("metadata should be written");
+
+        ensure_managed_install(&root).expect("valid metadata should be accepted");
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/app/src-tauri/src/server_creator.rs
+++ b/app/src-tauri/src/server_creator.rs
@@ -1,0 +1,687 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::VecDeque,
+    env,
+    ffi::OsStr,
+    fs,
+    io::{BufRead, BufReader, Read, Write},
+    net::{SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tauri::{AppHandle, Manager};
+
+const REPO_URL: &str = "https://github.com/SimonHazard/MemeOver";
+const LOG_LIMIT: usize = 500;
+
+/// Cloneable so commands can move an owned handle into `spawn_blocking`;
+/// the `Arc`s keep every clone pointing at the same child + log buffer.
+#[derive(Clone, Default)]
+pub struct ServerCreatorState {
+    child: Arc<Mutex<Option<Child>>>,
+    logs: Arc<Mutex<VecDeque<String>>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerInstallRequest {
+    install_dir: String,
+    discord_token: String,
+    discord_client_id: String,
+    ws_port: u16,
+    public_ws_url: String,
+    repair: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerCreatorStatus {
+    platform: String,
+    default_install_dir: String,
+    install_dir: String,
+    source_dir: String,
+    bot_dir: String,
+    installed: bool,
+    configured: bool,
+    bun_available: bool,
+    bun_path: Option<String>,
+    git_available: bool,
+    running: bool,
+    healthy: bool,
+    health_url: String,
+    local_ws_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerInstallResult {
+    install_dir: String,
+    local_ws_url: String,
+    public_ws_url: String,
+}
+
+/// All child processes must go through this constructor: on Windows a
+/// GUI-subsystem app otherwise flashes a console window per spawn.
+fn new_command(program: impl AsRef<OsStr>) -> Command {
+    let mut command = Command::new(program);
+    hide_console_window(&mut command);
+    command
+}
+
+#[cfg(windows)]
+fn hide_console_window(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn hide_console_window(_command: &mut Command) {}
+
+fn push_log(state: &ServerCreatorState, line: impl Into<String>) {
+    push_log_to(&state.logs, line);
+}
+
+fn push_log_to(logs: &Arc<Mutex<VecDeque<String>>>, line: impl Into<String>) {
+    let mut logs = match logs.lock() {
+        Ok(logs) => logs,
+        Err(_) => return,
+    };
+    if logs.len() >= LOG_LIMIT {
+        logs.pop_front();
+    }
+    logs.push_back(redact_secrets(&line.into()));
+}
+
+fn redact_secrets(line: &str) -> String {
+    if !line.split_whitespace().any(should_redact) {
+        return line.to_string();
+    }
+    line.split_whitespace()
+        .map(|part| if should_redact(part) { "[redacted]" } else { part })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn should_redact(part: &str) -> bool {
+    part.to_ascii_lowercase().contains("token=") || looks_like_discord_token(part)
+}
+
+/// Discord bot tokens are three dot-separated base64url segments
+/// (~24 / 6 / 38 chars); catch them even when not behind a `TOKEN=` prefix.
+fn looks_like_discord_token(part: &str) -> bool {
+    let is_segment = |s: &str| {
+        !s.is_empty()
+            && s.bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    };
+    let segments: Vec<&str> = part.split('.').collect();
+    let [a, b, c] = segments.as_slice() else {
+        return false;
+    };
+    a.len() >= 20
+        && (5..=10).contains(&b.len())
+        && c.len() >= 25
+        && is_segment(a)
+        && is_segment(b)
+        && is_segment(c)
+}
+
+fn app_default_install_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_local_data_dir()
+        .map(|p| p.join("MemeOver-Server"))
+        .map_err(|e| e.to_string())
+}
+
+fn normalize_install_dir(app: &AppHandle, install_dir: Option<String>) -> Result<PathBuf, String> {
+    match install_dir {
+        Some(raw) if !raw.trim().is_empty() => Ok(PathBuf::from(raw.trim())),
+        _ => app_default_install_dir(app),
+    }
+}
+
+fn source_dir(root: &Path) -> PathBuf {
+    root.join("MemeOver")
+}
+
+fn bot_dir(root: &Path) -> PathBuf {
+    source_dir(root).join("bot")
+}
+
+fn env_path(root: &Path) -> PathBuf {
+    bot_dir(root).join(".env")
+}
+
+fn package_json_path(root: &Path) -> PathBuf {
+    bot_dir(root).join("package.json")
+}
+
+fn command_exists(cmd: &str) -> bool {
+    new_command(cmd)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn bun_candidate_path() -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        env::var_os("USERPROFILE")
+            .map(PathBuf::from)
+            .map(|home| home.join(".bun").join("bin").join("bun.exe"))
+            .filter(|path| path.exists())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        env::var_os("HOME")
+            .map(PathBuf::from)
+            .map(|home| home.join(".bun").join("bin").join("bun"))
+            .filter(|path| path.exists())
+    }
+}
+
+fn bun_command() -> Option<String> {
+    if command_exists("bun") {
+        return Some("bun".to_string());
+    }
+
+    let candidate = bun_candidate_path()?;
+    if new_command(&candidate)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+    {
+        Some(candidate.to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+fn append_bun_path(command: &mut Command) {
+    let Some(candidate) = bun_candidate_path() else {
+        return;
+    };
+    let Some(bin_dir) = candidate.parent() else {
+        return;
+    };
+    let current = env::var_os("PATH").unwrap_or_default();
+    let mut paths = env::split_paths(&current).collect::<Vec<_>>();
+    if !paths.iter().any(|p| p == bin_dir) {
+        paths.insert(0, bin_dir.to_path_buf());
+        if let Ok(path) = env::join_paths(paths) {
+            command.env("PATH", path);
+        }
+    }
+}
+
+fn health_check(port: u16) -> bool {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let Ok(mut stream) = TcpStream::connect_timeout(&addr, Duration::from_millis(500)) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(800)));
+    let _ = stream.set_write_timeout(Some(Duration::from_millis(800)));
+
+    if stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .is_err()
+    {
+        return false;
+    }
+
+    let mut buffer = [0_u8; 128];
+    let Ok(bytes_read) = stream.read(&mut buffer) else {
+        return false;
+    };
+    let response = String::from_utf8_lossy(&buffer[..bytes_read]);
+    response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200")
+}
+
+fn prune_child(state: &ServerCreatorState) -> Result<bool, String> {
+    let mut guard = state
+        .child
+        .lock()
+        .map_err(|_| "Server process lock poisoned".to_string())?;
+
+    if let Some(child) = guard.as_mut() {
+        match child.try_wait().map_err(|e| e.to_string())? {
+            Some(status) => {
+                push_log(state, format!("Server process exited with {status}"));
+                *guard = None;
+                Ok(false)
+            }
+            None => Ok(true),
+        }
+    } else {
+        Ok(false)
+    }
+}
+
+fn run_logged(
+    state: &ServerCreatorState,
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+) -> Result<(), String> {
+    push_log(state, format!("Running: {} {}", program, args.join(" ")));
+
+    let output = new_command(program)
+        .args(args)
+        .current_dir(cwd.unwrap_or_else(|| Path::new(".")))
+        .output()
+        .map_err(|e| format!("Failed to run {program}: {e}"))?;
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        push_log(state, line);
+    }
+    for line in String::from_utf8_lossy(&output.stderr).lines() {
+        push_log(state, line);
+    }
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} failed with exit code {}",
+            program,
+            output.status.code().unwrap_or(-1)
+        ))
+    }
+}
+
+fn validate_runtime_request(req: &ServerInstallRequest) -> Result<(), String> {
+    if req.ws_port == 0 {
+        return Err("WebSocket port must be between 1 and 65535".to_string());
+    }
+    if !req.public_ws_url.starts_with("ws://") && !req.public_ws_url.starts_with("wss://") {
+        return Err("PUBLIC_WS_URL must start with ws:// or wss://".to_string());
+    }
+    Ok(())
+}
+
+fn validate_install_request(req: &ServerInstallRequest) -> Result<(), String> {
+    if req.discord_token.trim().is_empty() {
+        return Err("Discord token is required".to_string());
+    }
+    if req.discord_client_id.trim().len() < 17
+        || req.discord_client_id.trim().len() > 20
+        || !req
+            .discord_client_id
+            .trim()
+            .chars()
+            .all(|c| c.is_ascii_digit())
+    {
+        return Err("Discord Client ID must be a Discord snowflake".to_string());
+    }
+    validate_runtime_request(req)
+}
+
+fn write_env(root: &Path, req: &ServerInstallRequest) -> Result<(), String> {
+    let bot = bot_dir(root);
+    fs::create_dir_all(&bot).map_err(|e| e.to_string())?;
+    let content = format!(
+        "DISCORD_TOKEN={}\nDISCORD_CLIENT_ID={}\nWS_PORT={}\nPUBLIC_WS_URL={}\n",
+        req.discord_token.trim(),
+        req.discord_client_id.trim(),
+        req.ws_port,
+        req.public_ws_url.trim()
+    );
+    fs::write(env_path(root), content).map_err(|e| e.to_string())
+}
+
+fn install_sync(
+    app: &AppHandle,
+    state: &ServerCreatorState,
+    req: ServerInstallRequest,
+) -> Result<ServerInstallResult, String> {
+    let root = normalize_install_dir(app, Some(req.install_dir.clone()))?;
+
+    // Repair must work after an app restart, when the token only lives in
+    // the already-written .env: keep it instead of demanding it again.
+    let keep_existing_env = req.repair
+        && env_path(&root).exists()
+        && req.discord_token.trim().is_empty();
+    if keep_existing_env {
+        validate_runtime_request(&req)?;
+    } else {
+        validate_install_request(&req)?;
+    }
+
+    let source = source_dir(&root);
+    let bot = bot_dir(&root);
+    let bun = bun_command().ok_or_else(|| "Bun is not installed yet".to_string())?;
+
+    fs::create_dir_all(&root).map_err(|e| e.to_string())?;
+
+    if !package_json_path(&root).exists() {
+        if source.exists() {
+            return Err(
+                "Install folder already contains a MemeOver folder but no bot package".into(),
+            );
+        }
+        if !command_exists("git") {
+            return Err("Git is required to download MemeOver".to_string());
+        }
+        let clone_dest = source.to_string_lossy().to_string();
+        run_logged(
+            state,
+            "git",
+            &["clone", "--depth=1", REPO_URL, &clone_dest],
+            Some(&root),
+        )?;
+    } else if req.repair && source.join(".git").exists() {
+        run_logged(state, "git", &["pull", "--ff-only"], Some(&source))?;
+    } else {
+        push_log(state, "MemeOver source already installed");
+    }
+
+    if keep_existing_env {
+        push_log(state, "Keeping existing server configuration");
+    } else {
+        write_env(&root, &req)?;
+        push_log(state, "Server configuration saved");
+    }
+
+    // Only the bot workspace (and the shared package it links) is needed;
+    // skip the app's heavy frontend dependencies.
+    run_logged(
+        state,
+        &bun,
+        &[
+            "install",
+            "--filter",
+            "@memeover/bot",
+            "--filter",
+            "@memeover/shared",
+        ],
+        Some(&source),
+    )?;
+    push_log(state, "Dependencies installed");
+
+    if !bot.exists() {
+        return Err("Bot folder was not found after installation".to_string());
+    }
+
+    Ok(ServerInstallResult {
+        install_dir: root.to_string_lossy().to_string(),
+        local_ws_url: format!("ws://localhost:{}/ws", req.ws_port),
+        public_ws_url: req.public_ws_url,
+    })
+}
+
+fn spawn_log_reader(
+    logs: Arc<Mutex<VecDeque<String>>>,
+    reader: impl std::io::Read + Send + 'static,
+) {
+    std::thread::spawn(move || {
+        for line in BufReader::new(reader).lines().map_while(Result::ok) {
+            push_log_to(&logs, line);
+        }
+    });
+}
+
+fn status_sync(
+    app: &AppHandle,
+    state: &ServerCreatorState,
+    install_dir: Option<String>,
+    port: Option<u16>,
+) -> Result<ServerCreatorStatus, String> {
+    let default_root = app_default_install_dir(app)?;
+    let root = normalize_install_dir(app, install_dir)?;
+    let ws_port = port.unwrap_or(3001);
+    let running = prune_child(state)?;
+    let bun_path = bun_command();
+
+    Ok(ServerCreatorStatus {
+        platform: env::consts::OS.to_string(),
+        default_install_dir: default_root.to_string_lossy().to_string(),
+        install_dir: root.to_string_lossy().to_string(),
+        source_dir: source_dir(&root).to_string_lossy().to_string(),
+        bot_dir: bot_dir(&root).to_string_lossy().to_string(),
+        installed: package_json_path(&root).exists(),
+        configured: env_path(&root).exists(),
+        bun_available: bun_path.is_some(),
+        bun_path,
+        git_available: command_exists("git"),
+        running,
+        healthy: health_check(ws_port),
+        health_url: format!("http://localhost:{ws_port}/health"),
+        local_ws_url: format!("ws://localhost:{ws_port}/ws"),
+    })
+}
+
+fn install_bun_sync(state: &ServerCreatorState) -> Result<(), String> {
+    if bun_command().is_some() {
+        push_log(state, "Bun is already installed");
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    run_logged(
+        state,
+        "powershell",
+        &[
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            "irm https://bun.com/install.ps1 | iex",
+        ],
+        None,
+    )?;
+
+    #[cfg(not(target_os = "windows"))]
+    run_logged(
+        state,
+        "sh",
+        &["-c", "curl -fsSL https://bun.com/install | bash"],
+        None,
+    )?;
+
+    if bun_command().is_some() {
+        push_log(state, "Bun installed");
+        Ok(())
+    } else {
+        Err("Bun installer finished, but bun was not found".to_string())
+    }
+}
+
+fn start_sync(
+    app: &AppHandle,
+    state: &ServerCreatorState,
+    install_dir: Option<String>,
+) -> Result<(), String> {
+    if prune_child(state)? {
+        push_log(state, "Server is already running");
+        return Ok(());
+    }
+
+    let root = normalize_install_dir(app, install_dir)?;
+    let bot = bot_dir(&root);
+    if !bot.join("package.json").exists() {
+        return Err("Server is not installed yet".to_string());
+    }
+    let bun = bun_command().ok_or_else(|| "Bun is not installed yet".to_string())?;
+
+    // Run the entry file directly instead of `bun run start`: the start
+    // script spawns a nested bun, and `Child::kill` would only reach the
+    // outer one, leaving the actual bot alive.
+    let mut command = new_command(bun);
+    command
+        .args(["run", "src/index.ts"])
+        .current_dir(&bot)
+        .env("NODE_ENV", "production")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    append_bun_path(&mut command);
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("Failed to start server: {e}"))?;
+
+    if let Some(stdout) = child.stdout.take() {
+        spawn_log_reader(state.logs.clone(), stdout);
+    }
+    if let Some(stderr) = child.stderr.take() {
+        spawn_log_reader(state.logs.clone(), stderr);
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+    if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
+        push_log(
+            state,
+            format!("Server process exited immediately with {status}"),
+        );
+        return Err(format!("Server failed to start: {status}"));
+    }
+
+    *state
+        .child
+        .lock()
+        .map_err(|_| "Server process lock poisoned".to_string())? = Some(child);
+    push_log(state, "Server process started");
+    Ok(())
+}
+
+fn stop_process(state: &ServerCreatorState) -> Result<(), String> {
+    let mut guard = state
+        .child
+        .lock()
+        .map_err(|_| "Server process lock poisoned".to_string())?;
+
+    if let Some(child) = guard.as_mut() {
+        child.kill().map_err(|e| e.to_string())?;
+        let _ = child.wait();
+        push_log(state, "Server process stopped");
+    }
+    *guard = None;
+    Ok(())
+}
+
+/// Called from the app exit handler so the managed bot process does not
+/// outlive the app and keep its port bound.
+pub fn shutdown(state: &ServerCreatorState) {
+    let _ = stop_process(state);
+}
+
+/// Heavy or process-spawning work runs through `spawn_blocking`: non-async
+/// Tauri commands execute on the main thread and would freeze the UI.
+async fn run_blocking<T, F>(task: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(task)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn server_creator_status(
+    app: AppHandle,
+    state: tauri::State<'_, ServerCreatorState>,
+    install_dir: Option<String>,
+    port: Option<u16>,
+) -> Result<ServerCreatorStatus, String> {
+    let state = state.inner().clone();
+    run_blocking(move || status_sync(&app, &state, install_dir, port)).await
+}
+
+#[tauri::command]
+pub async fn server_creator_install(
+    app: AppHandle,
+    state: tauri::State<'_, ServerCreatorState>,
+    request: ServerInstallRequest,
+) -> Result<ServerInstallResult, String> {
+    let state = state.inner().clone();
+    run_blocking(move || install_sync(&app, &state, request)).await
+}
+
+#[tauri::command]
+pub async fn server_creator_install_bun(
+    state: tauri::State<'_, ServerCreatorState>,
+) -> Result<(), String> {
+    let state = state.inner().clone();
+    run_blocking(move || install_bun_sync(&state)).await
+}
+
+#[tauri::command]
+pub async fn server_creator_start(
+    app: AppHandle,
+    state: tauri::State<'_, ServerCreatorState>,
+    install_dir: Option<String>,
+) -> Result<(), String> {
+    let state = state.inner().clone();
+    run_blocking(move || start_sync(&app, &state, install_dir)).await
+}
+
+#[tauri::command]
+pub async fn server_creator_stop(
+    state: tauri::State<'_, ServerCreatorState>,
+) -> Result<(), String> {
+    let state = state.inner().clone();
+    run_blocking(move || stop_process(&state)).await
+}
+
+#[tauri::command]
+pub async fn server_creator_restart(
+    app: AppHandle,
+    state: tauri::State<'_, ServerCreatorState>,
+    install_dir: Option<String>,
+) -> Result<(), String> {
+    let state = state.inner().clone();
+    run_blocking(move || {
+        stop_process(&state)?;
+        start_sync(&app, &state, install_dir)
+    })
+    .await
+}
+
+#[tauri::command]
+pub fn server_creator_logs(
+    state: tauri::State<'_, ServerCreatorState>,
+) -> Result<Vec<String>, String> {
+    let logs = state
+        .logs
+        .lock()
+        .map_err(|_| "Server logs lock poisoned".to_string())?;
+    Ok(logs.iter().cloned().collect())
+}
+
+#[tauri::command]
+pub async fn server_creator_public_ip(
+    state: tauri::State<'_, ServerCreatorState>,
+) -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let endpoints = ["https://api4.my-ip.io/ip", "https://api.ipify.org"];
+    for endpoint in endpoints {
+        let Ok(response) = client.get(endpoint).send().await else {
+            continue;
+        };
+        if !response.status().is_success() {
+            continue;
+        }
+        let Ok(body) = response.text().await else {
+            continue;
+        };
+        let ip = body.trim().to_string();
+        if !ip.is_empty() {
+            push_log(&state, format!("Detected public IP: {ip}"));
+            return Ok(ip);
+        }
+    }
+    Err("Could not detect public IP automatically".to_string())
+}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "memeover",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "identifier": "com.simonhazard.memeover",
   "build": {
     "beforeDevCommand": "bun --bun run dev",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -214,8 +214,101 @@
 	"tabs": {
 		"dashboard": "Dashboard",
 		"overlay": "Overlay",
+		"server": "Server",
 		"history": "History",
 		"about": "About"
+	},
+	"server": {
+		"title": "Self-hosted server",
+		"subtitle": "Create your Discord bot, install the local server, and manage it directly from MemeOver. Technical files stay behind the scenes.",
+		"progress": "Progress",
+		"copy": "Copy",
+		"steps": {
+			"discord": "Create the Discord bot",
+			"configure": "Configure the server",
+			"install": "Install",
+			"run": "Run",
+			"connect": "Connect MemeOver",
+			"share": "Share with friends"
+		},
+		"status": {
+			"title": "Local status",
+			"running": "Running",
+			"portOpen": "Port open",
+			"stopped": "Stopped",
+			"ok": "OK",
+			"missing": "missing",
+			"installed": "Installed",
+			"notInstalled": "Not installed",
+			"configured": "Configured",
+			"notConfigured": "Not configured"
+		},
+		"logs": {
+			"title": "Logs",
+			"empty": "No server logs yet."
+		},
+		"discord": {
+			"title": "Create the Discord bot",
+			"desc": "Follow the Discord portal, then paste the token and Client ID here.",
+			"portal": "Portal",
+			"invite": "Invite bot",
+			"adminInvite": "Administrator invite",
+			"adminInviteHint": "Easier when channel permissions get in the way, but less minimal.",
+			"instructions": "In the Developer Portal: New Application, then Bot > Reset Token, enable Message Content Intent, copy the Application ID from General Information, then invite the bot with the button above. Recommended permissions: View Channels, Send Messages, Read Message History."
+		},
+		"config": {
+			"title": "Local configuration",
+			"desc": "Choose where to install the server and which URL your friends will use.",
+			"networkHint": "For friends outside your local network, open the chosen TCP port in your firewall and in your router NAT/port-forwarding rules to this machine."
+		},
+		"install": {
+			"title": "Install server",
+			"desc": "MemeOver downloads the server source, writes configuration, and installs dependencies.",
+			"bun": "Install Bun",
+			"bunReady": "Bun ready",
+			"install": "Install",
+			"installing": "Installing…",
+			"repair": "Repair",
+			"gitMissing": "Git is required to download MemeOver. Install Git, then run this step again.",
+			"securityNote": "The bot token is saved in plain text in the install folder (bot/.env) — anyone with access to this computer can read it. \"Install Bun\" runs the official installer from bun.com."
+		},
+		"run": {
+			"title": "Manage server",
+			"desc": "Start, stop, or restart the local server from this page.",
+			"start": "Start",
+			"stop": "Stop",
+			"restart": "Restart"
+		},
+		"connect": {
+			"title": "Connect MemeOver",
+			"desc": "Once the server is running, run /memeover setup in Discord and paste the code you receive.",
+			"apply": "Save local connection"
+		},
+		"share": {
+			"title": "Share with friends",
+			"desc": "Once /memeover setup has been applied, send this code to your friends.",
+			"empty": "The friend code will appear here after local connection.",
+			"copy": "Copy code"
+		},
+		"fields": {
+			"clientId": "Discord Client ID",
+			"botToken": "Bot token",
+			"installDir": "Install folder",
+			"port": "Port",
+			"publicWs": "Public WebSocket URL",
+			"setupCode": "/memeover setup code"
+		},
+		"toast": {
+			"bunInstalled": "Bun is installed",
+			"installed": "Server installed and configured",
+			"started": "Server started",
+			"stopped": "Server stopped",
+			"restarted": "Server restarted",
+			"ipDetected": "Public IP detected",
+			"connected": "Local connection saved",
+			"inviteCopied": "Invite link copied",
+			"setupCopied": "Code copied"
+		}
 	},
 	"about": {
 		"preferences": "Preferences",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -214,8 +214,101 @@
 	"tabs": {
 		"dashboard": "Dashboard",
 		"overlay": "Overlay",
+		"server": "Serveur",
 		"history": "Historique",
 		"about": "À propos"
+	},
+	"server": {
+		"title": "Serveur self-hosted",
+		"subtitle": "Créez votre bot Discord, installez le serveur local et gérez son lancement depuis MemeOver. Les fichiers techniques restent invisibles.",
+		"progress": "Progression",
+		"copy": "Copier",
+		"steps": {
+			"discord": "Créer le bot Discord",
+			"configure": "Configurer le serveur",
+			"install": "Installer",
+			"run": "Lancer",
+			"connect": "Connecter MemeOver",
+			"share": "Partager aux amis"
+		},
+		"status": {
+			"title": "État local",
+			"running": "En cours",
+			"portOpen": "Port ouvert",
+			"stopped": "Arrêté",
+			"ok": "OK",
+			"missing": "absent",
+			"installed": "Installé",
+			"notInstalled": "À installer",
+			"configured": "Configuré",
+			"notConfigured": "À configurer"
+		},
+		"logs": {
+			"title": "Logs",
+			"empty": "Aucun log serveur pour l'instant."
+		},
+		"discord": {
+			"title": "Créer le bot Discord",
+			"desc": "Suivez le portail Discord, puis collez le token et le Client ID ici.",
+			"portal": "Portail",
+			"invite": "Inviter le bot",
+			"adminInvite": "Invitation administrateur",
+			"adminInviteHint": "Plus simple si les permissions de salon bloquent, mais moins minimal.",
+			"instructions": "Dans le Developer Portal : New Application, puis Bot > Reset Token, activez Message Content Intent, copiez l'Application ID dans General Information, puis invitez le bot avec le bouton ci-dessus. Permissions recommandées : View Channels, Send Messages, Read Message History."
+		},
+		"config": {
+			"title": "Configuration locale",
+			"desc": "Choisissez où installer le serveur et quelle URL vos amis utiliseront.",
+			"networkHint": "Pour les amis hors réseau local, ouvrez le port TCP choisi dans votre pare-feu et dans la redirection NAT/PAT de votre box vers cette machine."
+		},
+		"install": {
+			"title": "Installer le serveur",
+			"desc": "MemeOver télécharge le code serveur, écrit la configuration et installe les dépendances.",
+			"bun": "Installer Bun",
+			"bunReady": "Bun prêt",
+			"install": "Installer",
+			"installing": "Installation…",
+			"repair": "Réparer",
+			"gitMissing": "Git est requis pour télécharger MemeOver. Installez Git, puis relancez cette étape.",
+			"securityNote": "Le token du bot est enregistré en clair dans le dossier d'installation (bot/.env) — toute personne ayant accès à cet ordinateur peut le lire. « Installer Bun » exécute l'installeur officiel depuis bun.com."
+		},
+		"run": {
+			"title": "Gérer le serveur",
+			"desc": "Lancez, arrêtez ou redémarrez le serveur local depuis cette page.",
+			"start": "Lancer",
+			"stop": "Arrêter",
+			"restart": "Redémarrer"
+		},
+		"connect": {
+			"title": "Connecter MemeOver",
+			"desc": "Quand le serveur tourne, lancez /memeover setup dans Discord et collez le code reçu.",
+			"apply": "Sauvegarder la connexion locale"
+		},
+		"share": {
+			"title": "Partager aux amis",
+			"desc": "Une fois /memeover setup appliqué, envoyez ce code à vos amis.",
+			"empty": "Le code ami apparaîtra ici après la connexion locale.",
+			"copy": "Copier le code"
+		},
+		"fields": {
+			"clientId": "Client ID Discord",
+			"botToken": "Token du bot",
+			"installDir": "Dossier d'installation",
+			"port": "Port",
+			"publicWs": "URL WebSocket publique",
+			"setupCode": "Code /memeover setup"
+		},
+		"toast": {
+			"bunInstalled": "Bun est installé",
+			"installed": "Serveur installé et configuré",
+			"started": "Serveur lancé",
+			"stopped": "Serveur arrêté",
+			"restarted": "Serveur redémarré",
+			"ipDetected": "IP publique détectée",
+			"connected": "Connexion locale sauvegardée",
+			"inviteCopied": "Lien d'invitation copié",
+			"setupCopied": "Code copié"
+		}
 	},
 	"about": {
 		"preferences": "Préférences",

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -9,11 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ServerRouteImport } from './routes/server'
 import { Route as OverlayRouteImport } from './routes/overlay'
 import { Route as HistoryRouteImport } from './routes/history'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 
+const ServerRoute = ServerRouteImport.update({
+  id: '/server',
+  path: '/server',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const OverlayRoute = OverlayRouteImport.update({
   id: '/overlay',
   path: '/overlay',
@@ -40,12 +46,14 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/history': typeof HistoryRoute
   '/overlay': typeof OverlayRoute
+  '/server': typeof ServerRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/history': typeof HistoryRoute
   '/overlay': typeof OverlayRoute
+  '/server': typeof ServerRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -53,13 +61,14 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/history': typeof HistoryRoute
   '/overlay': typeof OverlayRoute
+  '/server': typeof ServerRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/history' | '/overlay'
+  fullPaths: '/' | '/about' | '/history' | '/overlay' | '/server'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/history' | '/overlay'
-  id: '__root__' | '/' | '/about' | '/history' | '/overlay'
+  to: '/' | '/about' | '/history' | '/overlay' | '/server'
+  id: '__root__' | '/' | '/about' | '/history' | '/overlay' | '/server'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -67,10 +76,18 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   HistoryRoute: typeof HistoryRoute
   OverlayRoute: typeof OverlayRoute
+  ServerRoute: typeof ServerRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/server': {
+      id: '/server'
+      path: '/server'
+      fullPath: '/server'
+      preLoaderRoute: typeof ServerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/overlay': {
       id: '/overlay'
       path: '/overlay'
@@ -107,6 +124,7 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   HistoryRoute: HistoryRoute,
   OverlayRoute: OverlayRoute,
+  ServerRoute: ServerRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/app/src/routes/server.tsx
+++ b/app/src/routes/server.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ServerPage } from "@/windows/settings/pages/server";
+
+export const Route = createFileRoute("/server")({
+	component: ServerPage,
+});

--- a/app/src/shared/server-creator.test.ts
+++ b/app/src/shared/server-creator.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-	DISCORD_INVITE_PERMISSIONS,
 	createDiscordInviteUrl,
 	createFriendSetupCode,
 	createPublicWsUrl,
+	DISCORD_INVITE_PERMISSIONS,
 	parseServerSetupCode,
 } from "./server-creator";
 

--- a/app/src/shared/server-creator.test.ts
+++ b/app/src/shared/server-creator.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+	DISCORD_INVITE_PERMISSIONS,
+	createDiscordInviteUrl,
+	createFriendSetupCode,
+	createPublicWsUrl,
+	parseServerSetupCode,
+} from "./server-creator";
+
+const guildId = "123456789012345678";
+const token = "synthetic-friend-token";
+const wsUrl = "wss://friend.example/ws";
+
+describe("server creator helpers", () => {
+	test("builds public WebSocket URLs from trimmed hostnames", () => {
+		expect(createPublicWsUrl("  example.com  ", 3001)).toBe("ws://example.com:3001/ws");
+	});
+
+	test("preserves existing WebSocket URLs", () => {
+		expect(createPublicWsUrl("ws://localhost:3001/ws", 3001)).toBe("ws://localhost:3001/ws");
+		expect(createPublicWsUrl("wss://example.com/ws", 3001)).toBe("wss://example.com/ws");
+	});
+
+	test("returns a placeholder public WebSocket URL for blank input", () => {
+		expect(createPublicWsUrl("  ", 3001)).toBe("ws://YOUR_PUBLIC_IP:3001/ws");
+	});
+
+	test("rejects invalid Discord client IDs", () => {
+		expect(createDiscordInviteUrl("123")).toBeNull();
+		expect(createDiscordInviteUrl("not-a-client-id")).toBeNull();
+	});
+
+	test("builds Discord invite URLs with limited and administrator permissions", () => {
+		const defaultInvite = createDiscordInviteUrl("123456789012345678");
+		const adminInvite = createDiscordInviteUrl("123456789012345678", true);
+
+		expect(defaultInvite).not.toBeNull();
+		expect(adminInvite).not.toBeNull();
+
+		const defaultParams = new URL(defaultInvite ?? "").searchParams;
+		const adminParams = new URL(adminInvite ?? "").searchParams;
+
+		expect(defaultParams.get("client_id")).toBe("123456789012345678");
+		expect(defaultParams.get("scope")).toBe("bot applications.commands");
+		expect(defaultParams.get("permissions")).toBe(String(DISCORD_INVITE_PERMISSIONS));
+		expect(adminParams.get("permissions")).toBe("8");
+	});
+
+	test("returns null when setup code fields are blank", () => {
+		expect(createFriendSetupCode({ guildId: "", token, wsUrl })).toBeNull();
+		expect(createFriendSetupCode({ guildId, token: "", wsUrl })).toBeNull();
+		expect(createFriendSetupCode({ guildId, token, wsUrl: "" })).toBeNull();
+	});
+
+	test("builds parseable friend setup codes", () => {
+		const setupCode = createFriendSetupCode({ guildId, token, wsUrl });
+
+		expect(setupCode).not.toBeNull();
+		expect(setupCode?.startsWith("memeover://setup?")).toBe(true);
+		expect(parseServerSetupCode(setupCode ?? "")).toEqual({
+			guildId,
+			token,
+			wsUrl,
+		});
+	});
+
+	test("round-trips friend setup codes through the parser", () => {
+		const setupCode = createFriendSetupCode({ guildId, token, wsUrl });
+
+		expect(parseServerSetupCode(setupCode ?? "")).toEqual({
+			guildId,
+			token,
+			wsUrl,
+		});
+	});
+});

--- a/app/src/shared/server-creator.ts
+++ b/app/src/shared/server-creator.ts
@@ -1,0 +1,106 @@
+import { buildConnectionCode, parseConnectionCode } from "@memeover/shared";
+import { invoke } from "@tauri-apps/api/core";
+
+export const SERVER_CREATOR_DEFAULT_PORT = 3001;
+export const DISCORD_DEVELOPER_PORTAL_URL = "https://discord.com/developers/applications";
+export const DISCORD_INVITE_PERMISSIONS = 68608;
+
+export interface ServerCreatorStatus {
+	platform: string;
+	defaultInstallDir: string;
+	installDir: string;
+	sourceDir: string;
+	botDir: string;
+	installed: boolean;
+	configured: boolean;
+	bunAvailable: boolean;
+	bunPath: string | null;
+	gitAvailable: boolean;
+	running: boolean;
+	healthy: boolean;
+	healthUrl: string;
+	localWsUrl: string;
+}
+
+export interface ServerInstallRequest {
+	installDir: string;
+	discordToken: string;
+	discordClientId: string;
+	wsPort: number;
+	publicWsUrl: string;
+	repair: boolean;
+}
+
+export interface ServerInstallResult {
+	installDir: string;
+	localWsUrl: string;
+	publicWsUrl: string;
+}
+
+export function createPublicWsUrl(ipOrHost: string, port: number): string {
+	const host = ipOrHost.trim();
+	if (!host) return `ws://YOUR_PUBLIC_IP:${port}/ws`;
+	if (host.startsWith("ws://") || host.startsWith("wss://")) return host;
+	return `ws://${host}:${port}/ws`;
+}
+
+export function createDiscordInviteUrl(clientId: string, administrator = false): string | null {
+	const id = clientId.trim();
+	if (!/^\d{17,20}$/.test(id)) return null;
+	const permissions = administrator ? 8 : DISCORD_INVITE_PERMISSIONS;
+	const params = new URLSearchParams({
+		client_id: id,
+		scope: "bot applications.commands",
+		permissions: String(permissions),
+	});
+	return `https://discord.com/oauth2/authorize?${params.toString()}`;
+}
+
+export function createFriendSetupCode({
+	guildId,
+	token,
+	wsUrl,
+}: {
+	guildId: string;
+	token: string;
+	wsUrl: string;
+}): string | null {
+	if (!guildId || !token || !wsUrl) return null;
+	return buildConnectionCode({ guildId, token, wsUrl });
+}
+
+export function parseServerSetupCode(raw: string) {
+	return parseConnectionCode(raw);
+}
+
+export function serverCreatorStatus(installDir?: string, port?: number) {
+	return invoke<ServerCreatorStatus>("server_creator_status", { installDir, port });
+}
+
+export function serverCreatorInstall(request: ServerInstallRequest) {
+	return invoke<ServerInstallResult>("server_creator_install", { request });
+}
+
+export function serverCreatorInstallBun() {
+	return invoke<void>("server_creator_install_bun");
+}
+
+export function serverCreatorStart(installDir?: string) {
+	return invoke<void>("server_creator_start", { installDir });
+}
+
+export function serverCreatorStop() {
+	return invoke<void>("server_creator_stop");
+}
+
+export function serverCreatorRestart(installDir?: string) {
+	return invoke<void>("server_creator_restart", { installDir });
+}
+
+export function serverCreatorLogs() {
+	return invoke<string[]>("server_creator_logs");
+}
+
+export function serverCreatorPublicIp() {
+	return invoke<string>("server_creator_public_ip");
+}

--- a/app/src/windows/settings/components/server/discord-setup-card.tsx
+++ b/app/src/windows/settings/components/server/discord-setup-card.tsx
@@ -1,0 +1,101 @@
+import { NbButton } from "@memeover/ui/components/branded/nb-button";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Alert, AlertDescription } from "@memeover/ui/components/ui/alert";
+import { Input } from "@memeover/ui/components/ui/input";
+import { Separator } from "@memeover/ui/components/ui/separator";
+import { Switch } from "@memeover/ui/components/ui/switch";
+import { Clipboard, ExternalLink, ShieldCheck } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { FieldShell } from "./field-shell";
+
+export function DiscordSetupCard({
+	discordClientId,
+	discordToken,
+	administratorInvite,
+	inviteUrl,
+	onDiscordClientIdChange,
+	onDiscordTokenChange,
+	onAdministratorInviteChange,
+	onOpenPortal,
+	onOpenInvite,
+	onCopyInvite,
+}: {
+	discordClientId: string;
+	discordToken: string;
+	administratorInvite: boolean;
+	inviteUrl: string | null;
+	onDiscordClientIdChange: (value: string) => void;
+	onDiscordTokenChange: (value: string) => void;
+	onAdministratorInviteChange: (value: boolean) => void;
+	onOpenPortal: () => void;
+	onOpenInvite: () => void;
+	onCopyInvite: () => void;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-4">
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<h2 className="font-display text-base tracking-wide">{t("server.discord.title")}</h2>
+						<p className="mt-1 font-text text-sm text-muted-foreground">
+							{t("server.discord.desc")}
+						</p>
+					</div>
+					<NbButton size="sm" variant="outline" onClick={onOpenPortal}>
+						<ExternalLink className="size-3.5" aria-hidden="true" />
+						{t("server.discord.portal")}
+					</NbButton>
+				</div>
+
+				<Separator />
+
+				<div className="grid gap-3 md:grid-cols-2">
+					<FieldShell label={t("server.fields.clientId")}>
+						<Input
+							value={discordClientId}
+							onChange={(event) => onDiscordClientIdChange(event.target.value)}
+							placeholder="123456789012345678"
+						/>
+					</FieldShell>
+					<FieldShell label={t("server.fields.botToken")}>
+						<Input
+							type="password"
+							value={discordToken}
+							onChange={(event) => onDiscordTokenChange(event.target.value)}
+							placeholder="xxxxxxxxxxxxxxxx"
+						/>
+					</FieldShell>
+				</div>
+
+				<div className="flex items-center justify-between gap-3 rounded-lg border-2 border-border p-3">
+					<div className="flex flex-col gap-1">
+						<span className="font-display text-xs tracking-wide">
+							{t("server.discord.adminInvite")}
+						</span>
+						<span className="font-text text-xs text-muted-foreground">
+							{t("server.discord.adminInviteHint")}
+						</span>
+					</div>
+					<Switch checked={administratorInvite} onCheckedChange={onAdministratorInviteChange} />
+				</div>
+
+				<div className="flex flex-wrap gap-2">
+					<NbButton disabled={!inviteUrl} onClick={onOpenInvite}>
+						<ShieldCheck className="size-4" aria-hidden="true" />
+						{t("server.discord.invite")}
+					</NbButton>
+					<NbButton variant="outline" disabled={!inviteUrl} onClick={onCopyInvite}>
+						<Clipboard className="size-4" aria-hidden="true" />
+						{t("server.copy")}
+					</NbButton>
+				</div>
+
+				<Alert>
+					<AlertDescription>{t("server.discord.instructions")}</AlertDescription>
+				</Alert>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/field-shell.tsx
+++ b/app/src/windows/settings/components/server/field-shell.tsx
@@ -1,0 +1,20 @@
+import { Label } from "@memeover/ui/components/ui/label";
+import type { ReactNode } from "react";
+
+export function FieldShell({
+	label,
+	hint,
+	children,
+}: {
+	label: string;
+	hint?: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-2">
+			<Label className="font-display text-xs tracking-wide">{label}</Label>
+			{children}
+			{hint && <p className="font-text text-xs text-muted-foreground">{hint}</p>}
+		</div>
+	);
+}

--- a/app/src/windows/settings/components/server/server-config-card.tsx
+++ b/app/src/windows/settings/components/server/server-config-card.tsx
@@ -1,0 +1,85 @@
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Alert, AlertDescription } from "@memeover/ui/components/ui/alert";
+import { Button } from "@memeover/ui/components/ui/button";
+import { Input } from "@memeover/ui/components/ui/input";
+import { Separator } from "@memeover/ui/components/ui/separator";
+import { FolderOpen, Globe2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { FieldShell } from "./field-shell";
+
+export function ServerConfigCard({
+	installDir,
+	port,
+	publicWsUrl,
+	detectIpPending,
+	onInstallDirChange,
+	onPortChange,
+	onPublicWsUrlChange,
+	onChooseInstallDir,
+	onDetectIp,
+}: {
+	installDir: string;
+	port: string;
+	publicWsUrl: string;
+	detectIpPending: boolean;
+	onInstallDirChange: (value: string) => void;
+	onPortChange: (value: string) => void;
+	onPublicWsUrlChange: (value: string) => void;
+	onChooseInstallDir: () => void;
+	onDetectIp: () => void;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-4">
+				<div>
+					<h2 className="font-display text-base tracking-wide">{t("server.config.title")}</h2>
+					<p className="mt-1 font-text text-sm text-muted-foreground">{t("server.config.desc")}</p>
+				</div>
+				<Separator />
+				<FieldShell label={t("server.fields.installDir")}>
+					<div className="flex gap-2">
+						<Input
+							value={installDir}
+							onChange={(event) => onInstallDirChange(event.target.value)}
+						/>
+						<Button
+							type="button"
+							variant="outline"
+							aria-label={t("server.fields.installDir")}
+							onClick={onChooseInstallDir}
+						>
+							<FolderOpen className="size-4" aria-hidden="true" />
+						</Button>
+					</div>
+				</FieldShell>
+				<div className="grid gap-3 md:grid-cols-[140px_minmax(0,1fr)]">
+					<FieldShell label={t("server.fields.port")}>
+						<Input value={port} onChange={(event) => onPortChange(event.target.value)} />
+					</FieldShell>
+					<FieldShell label={t("server.fields.publicWs")}>
+						<div className="flex gap-2">
+							<Input
+								value={publicWsUrl}
+								onChange={(event) => onPublicWsUrlChange(event.target.value)}
+							/>
+							<Button
+								type="button"
+								variant="outline"
+								aria-label={t("server.toast.ipDetected")}
+								disabled={detectIpPending}
+								onClick={onDetectIp}
+							>
+								<Globe2 className="size-4" aria-hidden="true" />
+							</Button>
+						</div>
+					</FieldShell>
+				</div>
+				<Alert>
+					<AlertDescription>{t("server.config.networkHint")}</AlertDescription>
+				</Alert>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-connect-card.tsx
+++ b/app/src/windows/settings/components/server/server-connect-card.tsx
@@ -1,0 +1,42 @@
+import { NbButton } from "@memeover/ui/components/branded/nb-button";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Input } from "@memeover/ui/components/ui/input";
+import { Separator } from "@memeover/ui/components/ui/separator";
+import { KeyRound } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { FieldShell } from "./field-shell";
+
+export function ServerConnectCard({
+	setupCode,
+	onSetupCodeChange,
+	onApplySetupCode,
+}: {
+	setupCode: string;
+	onSetupCodeChange: (value: string) => void;
+	onApplySetupCode: () => void;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-4">
+				<div>
+					<h2 className="font-display text-base tracking-wide">{t("server.connect.title")}</h2>
+					<p className="mt-1 font-text text-sm text-muted-foreground">{t("server.connect.desc")}</p>
+				</div>
+				<Separator />
+				<FieldShell label={t("server.fields.setupCode")}>
+					<Input
+						value={setupCode}
+						onChange={(event) => onSetupCodeChange(event.target.value)}
+						placeholder="memeover://setup?guild_id=..."
+					/>
+				</FieldShell>
+				<NbButton disabled={!setupCode} onClick={onApplySetupCode}>
+					<KeyRound className="size-4" aria-hidden="true" />
+					{t("server.connect.apply")}
+				</NbButton>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-header.tsx
+++ b/app/src/windows/settings/components/server/server-header.tsx
@@ -1,0 +1,31 @@
+import { Progress } from "@memeover/ui/components/ui/progress";
+import { Server } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ServerCreatorStatus } from "@/shared/server-creator";
+import { StatusBadge } from "./status-badge";
+
+export function ServerHeader({
+	status,
+	progress,
+}: {
+	status?: ServerCreatorStatus;
+	progress: number;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+			<div className="flex flex-col gap-1">
+				<div className="flex items-center gap-2">
+					<Server className="size-6" aria-hidden="true" />
+					<h1 className="font-display text-2xl tracking-wide">{t("server.title")}</h1>
+					<StatusBadge status={status} />
+				</div>
+				<p className="max-w-3xl font-text text-sm text-muted-foreground">{t("server.subtitle")}</p>
+			</div>
+			<div className="min-w-56">
+				<Progress value={progress} />
+			</div>
+		</div>
+	);
+}

--- a/app/src/windows/settings/components/server/server-install-card.tsx
+++ b/app/src/windows/settings/components/server/server-install-card.tsx
@@ -1,0 +1,77 @@
+import { NbBadge } from "@memeover/ui/components/branded/nb-badge";
+import { NbButton } from "@memeover/ui/components/branded/nb-button";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Alert, AlertDescription } from "@memeover/ui/components/ui/alert";
+import { Separator } from "@memeover/ui/components/ui/separator";
+import { Hammer, RefreshCw, Wrench } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ServerCreatorStatus } from "@/shared/server-creator";
+
+export function ServerInstallCard({
+	status,
+	installDisabled,
+	installPending,
+	installBunPending,
+	onInstallBun,
+	onInstall,
+	onRepair,
+}: {
+	status?: ServerCreatorStatus;
+	installDisabled: boolean;
+	installPending: boolean;
+	installBunPending: boolean;
+	onInstallBun: () => void;
+	onInstall: () => void;
+	onRepair: () => void;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-4">
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<h2 className="font-display text-base tracking-wide">{t("server.install.title")}</h2>
+						<p className="mt-1 font-text text-sm text-muted-foreground">
+							{t("server.install.desc")}
+						</p>
+					</div>
+					<NbBadge variant={status?.installed ? "default" : "outline"}>
+						{status?.installed ? t("server.status.installed") : t("server.status.notInstalled")}
+					</NbBadge>
+				</div>
+				<Separator />
+				<div className="flex flex-wrap gap-2">
+					<NbButton
+						variant="outline"
+						disabled={status?.bunAvailable || installBunPending}
+						onClick={onInstallBun}
+					>
+						<Wrench className="size-4" aria-hidden="true" />
+						{status?.bunAvailable ? t("server.install.bunReady") : t("server.install.bun")}
+					</NbButton>
+					<NbButton disabled={installDisabled} onClick={onInstall}>
+						<Hammer className="size-4" aria-hidden="true" />
+						{installPending ? t("server.install.installing") : t("server.install.install")}
+					</NbButton>
+					<NbButton
+						variant="outline"
+						disabled={!status?.installed || installPending}
+						onClick={onRepair}
+					>
+						<RefreshCw className="size-4" aria-hidden="true" />
+						{t("server.install.repair")}
+					</NbButton>
+				</div>
+				{!status?.gitAvailable && (
+					<Alert variant="destructive">
+						<AlertDescription>{t("server.install.gitMissing")}</AlertDescription>
+					</Alert>
+				)}
+				<p className="font-text text-xs text-muted-foreground">
+					{t("server.install.securityNote")}
+				</p>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-logs-card.tsx
+++ b/app/src/windows/settings/components/server/server-logs-card.tsx
@@ -1,0 +1,39 @@
+import { NbBadge } from "@memeover/ui/components/branded/nb-badge";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { ScrollArea } from "@memeover/ui/components/ui/scroll-area";
+import { Skeleton } from "@memeover/ui/components/ui/skeleton";
+import { Terminal } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export function ServerLogsCard({ logs, loading }: { logs: string[]; loading: boolean }) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-3">
+				<div className="flex items-center justify-between gap-3">
+					<div className="flex items-center gap-2">
+						<Terminal className="size-4" aria-hidden="true" />
+						<h2 className="font-display text-sm tracking-wide">{t("server.logs.title")}</h2>
+					</div>
+					<NbBadge variant="outline">{logs.length}</NbBadge>
+				</div>
+				<ScrollArea className="h-44 rounded-md border-2 border-foreground bg-foreground p-3 text-background">
+					{loading ? (
+						<div className="flex flex-col gap-2">
+							<Skeleton className="h-4 w-5/6 bg-background/20" />
+							<Skeleton className="h-4 w-2/3 bg-background/20" />
+							<Skeleton className="h-4 w-4/5 bg-background/20" />
+						</div>
+					) : logs.length === 0 ? (
+						<p className="font-mono text-xs opacity-70">{t("server.logs.empty")}</p>
+					) : (
+						<pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+							{logs.slice(-140).join("\n")}
+						</pre>
+					)}
+				</ScrollArea>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-progress-card.tsx
+++ b/app/src/windows/settings/components/server/server-progress-card.tsx
@@ -1,0 +1,36 @@
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { cn } from "@memeover/ui/lib/utils";
+import { CheckCircle2, Circle } from "lucide-react";
+import type { ServerStep, StepState } from "./types";
+
+function StepItem({ index, title, state }: { index: number; title: string; state: StepState }) {
+	const Icon = state === "done" ? CheckCircle2 : Circle;
+
+	return (
+		<div
+			className={cn(
+				"flex items-center gap-2 rounded-lg border-2 px-3 py-2 font-text text-sm",
+				state === "done" && "border-foreground bg-primary/10 text-foreground",
+				state === "active" && "border-foreground bg-secondary/10 text-foreground",
+				state === "idle" && "border-border text-muted-foreground",
+			)}
+		>
+			<Icon className="size-4 shrink-0" aria-hidden="true" />
+			<span className="font-display text-xs tracking-wide">{index}.</span>
+			<span className="min-w-0 truncate">{title}</span>
+		</div>
+	);
+}
+
+export function ServerProgressCard({ title, steps }: { title: string; steps: ServerStep[] }) {
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-3">
+				<h2 className="font-display text-sm tracking-wide">{title}</h2>
+				{steps.map((step, index) => (
+					<StepItem key={step.title} index={index + 1} title={step.title} state={step.state} />
+				))}
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-run-card.tsx
+++ b/app/src/windows/settings/components/server/server-run-card.tsx
@@ -1,0 +1,68 @@
+import { NbButton } from "@memeover/ui/components/branded/nb-button";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Separator } from "@memeover/ui/components/ui/separator";
+import { Play, RefreshCw, Square } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ServerCreatorStatus } from "@/shared/server-creator";
+import { StatusBadge } from "./status-badge";
+
+export function ServerRunCard({
+	status,
+	wsPort,
+	startPending,
+	stopPending,
+	restartPending,
+	onStart,
+	onStop,
+	onRestart,
+}: {
+	status?: ServerCreatorStatus;
+	wsPort: number;
+	startPending: boolean;
+	stopPending: boolean;
+	restartPending: boolean;
+	onStart: () => void;
+	onStop: () => void;
+	onRestart: () => void;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-4">
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<h2 className="font-display text-base tracking-wide">{t("server.run.title")}</h2>
+						<p className="mt-1 font-text text-sm text-muted-foreground">{t("server.run.desc")}</p>
+					</div>
+					<StatusBadge status={status} />
+				</div>
+				<Separator />
+				<div className="flex flex-wrap gap-2">
+					<NbButton
+						disabled={!status?.installed || !!status?.running || !!status?.healthy || startPending}
+						onClick={onStart}
+					>
+						<Play className="size-4" aria-hidden="true" />
+						{t("server.run.start")}
+					</NbButton>
+					<NbButton variant="outline" disabled={!status?.running || stopPending} onClick={onStop}>
+						<Square className="size-4" aria-hidden="true" />
+						{t("server.run.stop")}
+					</NbButton>
+					<NbButton
+						variant="outline"
+						disabled={!status?.installed || restartPending}
+						onClick={onRestart}
+					>
+						<RefreshCw className="size-4" aria-hidden="true" />
+						{t("server.run.restart")}
+					</NbButton>
+				</div>
+				<p className="break-all font-mono text-xs text-muted-foreground">
+					{status?.healthUrl ?? `http://localhost:${wsPort}/health`}
+				</p>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-share-card.tsx
+++ b/app/src/windows/settings/components/server/server-share-card.tsx
@@ -1,0 +1,36 @@
+import { NbButton } from "@memeover/ui/components/branded/nb-button";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Separator } from "@memeover/ui/components/ui/separator";
+import { Clipboard } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+export function ServerShareCard({
+	friendSetupCode,
+	onCopySetupCode,
+}: {
+	friendSetupCode: string | null;
+	onCopySetupCode: () => void;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-4">
+				<div>
+					<h2 className="font-display text-base tracking-wide">{t("server.share.title")}</h2>
+					<p className="mt-1 font-text text-sm text-muted-foreground">{t("server.share.desc")}</p>
+				</div>
+				<Separator />
+				<div className="rounded-md border-2 border-foreground bg-muted p-3">
+					<pre className="whitespace-pre-wrap break-all font-mono text-xs">
+						{friendSetupCode ?? t("server.share.empty")}
+					</pre>
+				</div>
+				<NbButton disabled={!friendSetupCode} onClick={onCopySetupCode}>
+					<Clipboard className="size-4" aria-hidden="true" />
+					{t("server.share.copy")}
+				</NbButton>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/server-status-card.tsx
+++ b/app/src/windows/settings/components/server/server-status-card.tsx
@@ -1,0 +1,45 @@
+import { NbBadge } from "@memeover/ui/components/branded/nb-badge";
+import { NbCard } from "@memeover/ui/components/branded/nb-card";
+import { Skeleton } from "@memeover/ui/components/ui/skeleton";
+import { useTranslation } from "react-i18next";
+import type { ServerCreatorStatus } from "@/shared/server-creator";
+
+export function ServerStatusCard({
+	status,
+	loading,
+	wsPort,
+}: {
+	status?: ServerCreatorStatus;
+	loading: boolean;
+	wsPort: number;
+}) {
+	const { t } = useTranslation();
+
+	return (
+		<NbCard>
+			<div className="flex flex-col gap-3">
+				<div className="flex items-center justify-between gap-3">
+					<h2 className="font-display text-sm tracking-wide">{t("server.status.title")}</h2>
+					{loading && <Skeleton className="h-5 w-14" />}
+				</div>
+				<div className="grid grid-cols-2 gap-2 text-xs">
+					<NbBadge variant={status?.bunAvailable ? "default" : "outline"}>
+						Bun {status?.bunAvailable ? t("server.status.ok") : t("server.status.missing")}
+					</NbBadge>
+					<NbBadge variant={status?.gitAvailable ? "default" : "outline"}>
+						Git {status?.gitAvailable ? t("server.status.ok") : t("server.status.missing")}
+					</NbBadge>
+					<NbBadge variant={status?.installed ? "default" : "outline"}>
+						{status?.installed ? t("server.status.installed") : t("server.status.notInstalled")}
+					</NbBadge>
+					<NbBadge variant={status?.configured ? "default" : "outline"}>
+						{status?.configured ? t("server.status.configured") : t("server.status.notConfigured")}
+					</NbBadge>
+				</div>
+				<p className="break-all font-mono text-xs text-muted-foreground">
+					{status?.localWsUrl ?? `ws://localhost:${wsPort}/ws`}
+				</p>
+			</div>
+		</NbCard>
+	);
+}

--- a/app/src/windows/settings/components/server/status-badge.tsx
+++ b/app/src/windows/settings/components/server/status-badge.tsx
@@ -1,0 +1,11 @@
+import { NbBadge } from "@memeover/ui/components/branded/nb-badge";
+import { useTranslation } from "react-i18next";
+import type { ServerCreatorStatus } from "@/shared/server-creator";
+
+export function StatusBadge({ status }: { status?: ServerCreatorStatus }) {
+	const { t } = useTranslation();
+	if (!status) return <NbBadge variant="outline">...</NbBadge>;
+	if (status.healthy) return <NbBadge variant="secondary">{t("server.status.portOpen")}</NbBadge>;
+	if (status.running) return <NbBadge variant="default">{t("server.status.running")}</NbBadge>;
+	return <NbBadge variant="outline">{t("server.status.stopped")}</NbBadge>;
+}

--- a/app/src/windows/settings/components/server/types.ts
+++ b/app/src/windows/settings/components/server/types.ts
@@ -1,0 +1,6 @@
+export type StepState = "done" | "active" | "idle";
+
+export interface ServerStep {
+	title: string;
+	state: StepState;
+}

--- a/app/src/windows/settings/components/tab-nav.tsx
+++ b/app/src/windows/settings/components/tab-nav.tsx
@@ -3,7 +3,7 @@ import { NB_SHADOW_MD, NB_SHADOW_SM } from "@memeover/ui/lib/nb-classes";
 import { cn } from "@memeover/ui/lib/utils";
 import type { FileRoutesByPath } from "@tanstack/react-router";
 import { useLocation, useNavigate } from "@tanstack/react-router";
-import { History, LayoutDashboard, Monitor, Settings } from "lucide-react";
+import { History, LayoutDashboard, Monitor, Server, Settings } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "@/shared/store";
 
@@ -22,6 +22,7 @@ interface TabDef {
 const TABS: TabDef[] = [
 	{ route: "/", icon: LayoutDashboard, labelKey: "tabs.dashboard" },
 	{ route: "/overlay", icon: Monitor, labelKey: "tabs.overlay" },
+	{ route: "/server", icon: Server, labelKey: "tabs.server" },
 	{ route: "/history", icon: History, labelKey: "tabs.history" },
 	{ route: "/about", icon: Settings, labelKey: "tabs.about" },
 ];

--- a/app/src/windows/settings/hooks/use-server-page.ts
+++ b/app/src/windows/settings/hooks/use-server-page.ts
@@ -1,0 +1,329 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { create } from "zustand";
+import {
+	createDiscordInviteUrl,
+	createFriendSetupCode,
+	createPublicWsUrl,
+	DISCORD_DEVELOPER_PORTAL_URL,
+	parseServerSetupCode,
+	SERVER_CREATOR_DEFAULT_PORT,
+	serverCreatorInstall,
+	serverCreatorInstallBun,
+	serverCreatorLogs,
+	serverCreatorPublicIp,
+	serverCreatorRestart,
+	serverCreatorStart,
+	serverCreatorStatus,
+	serverCreatorStop,
+} from "@/shared/server-creator";
+import { loadSettings, persistSettings } from "@/shared/settings";
+import type { ServerStep } from "@/windows/settings/components/server/types";
+
+function mutationError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+interface ServerFormFields {
+	installDir: string;
+	discordToken: string;
+	discordClientId: string;
+	port: string;
+	publicWsUrl: string;
+	setupCode: string;
+	guildId: string;
+	guildToken: string;
+	administratorInvite: boolean;
+}
+
+/** Module-level store so wizard inputs (token included) survive tab
+ *  navigation — the page unmounts and useState would wipe them. */
+const useServerFormStore = create<
+	ServerFormFields & {
+		setField: <K extends keyof ServerFormFields>(key: K, value: ServerFormFields[K]) => void;
+	}
+>((set) => ({
+	installDir: "",
+	discordToken: "",
+	discordClientId: "",
+	port: String(SERVER_CREATOR_DEFAULT_PORT),
+	publicWsUrl: createPublicWsUrl("YOUR_PUBLIC_IP", SERVER_CREATOR_DEFAULT_PORT),
+	setupCode: "",
+	guildId: "",
+	guildToken: "",
+	administratorInvite: false,
+	setField: (key, value) => set({ [key]: value } as Partial<ServerFormFields>),
+}));
+
+export function useServerPage() {
+	const { t } = useTranslation();
+	const queryClient = useQueryClient();
+	const {
+		installDir,
+		discordToken,
+		discordClientId,
+		port,
+		publicWsUrl,
+		setupCode,
+		guildId,
+		guildToken,
+		administratorInvite,
+		setField,
+	} = useServerFormStore();
+	const setInstallDir = (value: string) => setField("installDir", value);
+	const setPublicWsUrl = (value: string) => setField("publicWsUrl", value);
+
+	const wsPort = Number.parseInt(port, 10) || SERVER_CREATOR_DEFAULT_PORT;
+	const statusKeyInstallDir = installDir.trim() || undefined;
+
+	const { data: status, isLoading: statusLoading } = useQuery({
+		queryKey: ["serverCreatorStatus", statusKeyInstallDir, wsPort],
+		queryFn: () => serverCreatorStatus(statusKeyInstallDir, wsPort),
+		refetchInterval: 2_000,
+		placeholderData: keepPreviousData,
+	});
+
+	const { data: logs = [], isLoading: logsLoading } = useQuery({
+		queryKey: ["serverCreatorLogs"],
+		queryFn: serverCreatorLogs,
+		refetchInterval: 2_000,
+		placeholderData: keepPreviousData,
+	});
+
+	useEffect(() => {
+		if (!installDir && status?.defaultInstallDir) {
+			setField("installDir", status.defaultInstallDir);
+		}
+	}, [installDir, status?.defaultInstallDir, setField]);
+
+	const inviteUrl = useMemo(
+		() => createDiscordInviteUrl(discordClientId, administratorInvite),
+		[administratorInvite, discordClientId],
+	);
+	const friendSetupCode = useMemo(
+		() => createFriendSetupCode({ guildId, token: guildToken, wsUrl: publicWsUrl }),
+		[guildId, guildToken, publicWsUrl],
+	);
+	const progress = useMemo(() => {
+		const checks = [
+			!!discordToken && !!inviteUrl,
+			!!installDir && !!publicWsUrl,
+			!!status?.installed && !!status?.configured,
+			!!status?.running || !!status?.healthy,
+			!!guildId && !!guildToken,
+			!!friendSetupCode,
+		];
+		return (checks.filter(Boolean).length / checks.length) * 100;
+	}, [
+		discordToken,
+		friendSetupCode,
+		guildId,
+		guildToken,
+		installDir,
+		inviteUrl,
+		publicWsUrl,
+		status?.configured,
+		status?.healthy,
+		status?.installed,
+		status?.running,
+	]);
+
+	const steps: ServerStep[] = [
+		{
+			title: t("server.steps.discord"),
+			state: discordToken && inviteUrl ? "done" : "active",
+		},
+		{
+			title: t("server.steps.configure"),
+			state: installDir && publicWsUrl ? "done" : discordToken ? "active" : "idle",
+		},
+		{
+			title: t("server.steps.install"),
+			state: status?.installed && status?.configured ? "done" : installDir ? "active" : "idle",
+		},
+		{
+			title: t("server.steps.run"),
+			state: status?.running || status?.healthy ? "done" : status?.installed ? "active" : "idle",
+		},
+		{
+			title: t("server.steps.connect"),
+			state:
+				guildId && guildToken ? "done" : status?.running || status?.healthy ? "active" : "idle",
+		},
+		{
+			title: t("server.steps.share"),
+			state: friendSetupCode ? "done" : guildId && guildToken ? "active" : "idle",
+		},
+	];
+
+	const invalidateServer = () => {
+		void queryClient.invalidateQueries({ queryKey: ["serverCreatorStatus"] });
+		void queryClient.invalidateQueries({ queryKey: ["serverCreatorLogs"] });
+	};
+
+	const installBunMutation = useMutation({
+		mutationFn: serverCreatorInstallBun,
+		onSuccess: () => {
+			toast.success(t("server.toast.bunInstalled"));
+			invalidateServer();
+		},
+		onError: (error) => toast.error(mutationError(error)),
+	});
+
+	const installMutation = useMutation({
+		mutationFn: (repair: boolean) =>
+			serverCreatorInstall({
+				installDir,
+				discordToken,
+				discordClientId,
+				wsPort,
+				publicWsUrl,
+				repair,
+			}),
+		onSuccess: (result) => {
+			setInstallDir(result.installDir);
+			toast.success(t("server.toast.installed"));
+			invalidateServer();
+		},
+		onError: (error) => toast.error(mutationError(error)),
+	});
+
+	const startMutation = useMutation({
+		mutationFn: () => serverCreatorStart(installDir),
+		onSuccess: () => {
+			toast.success(t("server.toast.started"));
+			invalidateServer();
+		},
+		onError: (error) => toast.error(mutationError(error)),
+	});
+
+	const stopMutation = useMutation({
+		mutationFn: serverCreatorStop,
+		onSuccess: () => {
+			toast.success(t("server.toast.stopped"));
+			invalidateServer();
+		},
+		onError: (error) => toast.error(mutationError(error)),
+	});
+
+	const restartMutation = useMutation({
+		mutationFn: () => serverCreatorRestart(installDir),
+		onSuccess: () => {
+			toast.success(t("server.toast.restarted"));
+			invalidateServer();
+		},
+		onError: (error) => toast.error(mutationError(error)),
+	});
+
+	const detectIpMutation = useMutation({
+		mutationFn: serverCreatorPublicIp,
+		onSuccess: (ip) => {
+			setPublicWsUrl(createPublicWsUrl(ip, wsPort));
+			toast.success(t("server.toast.ipDetected"));
+			invalidateServer();
+		},
+		onError: (error) => toast.error(mutationError(error)),
+	});
+
+	async function chooseInstallDir() {
+		const selected = await openDialog({
+			directory: true,
+			multiple: false,
+			defaultPath: installDir || status?.defaultInstallDir,
+		});
+		if (typeof selected === "string") {
+			setInstallDir(selected);
+		}
+	}
+
+	async function copyText(value: string, message: string) {
+		await navigator.clipboard.writeText(value);
+		toast.success(message);
+	}
+
+	async function applySetupCode() {
+		const parsed = parseServerSetupCode(setupCode);
+		if (!parsed) {
+			toast.error(t("toast.connectionImportError"));
+			return;
+		}
+
+		const localWsUrl = `ws://localhost:${wsPort}/ws`;
+		const current = await queryClient.fetchQuery({
+			queryKey: ["settings"],
+			queryFn: loadSettings,
+		});
+		await persistSettings({
+			...current,
+			wsUrl: localWsUrl,
+			expertMode: true,
+			guildId: parsed.guildId,
+			token: parsed.token,
+		});
+		setField("guildId", parsed.guildId);
+		setField("guildToken", parsed.token);
+		void queryClient.invalidateQueries({ queryKey: ["settings"] });
+		toast.success(t("server.toast.connected"));
+	}
+
+	const installDisabled =
+		!installDir ||
+		!discordToken ||
+		!inviteUrl ||
+		!publicWsUrl ||
+		installMutation.isPending ||
+		installBunMutation.isPending;
+
+	return {
+		administratorInvite,
+		detectIpPending: detectIpMutation.isPending,
+		discordClientId,
+		discordToken,
+		friendSetupCode,
+		installBunPending: installBunMutation.isPending,
+		installDir,
+		installDisabled,
+		installPending: installMutation.isPending,
+		inviteUrl,
+		logs,
+		logsLoading,
+		port,
+		progress,
+		publicWsUrl,
+		restartPending: restartMutation.isPending,
+		setupCode,
+		startPending: startMutation.isPending,
+		status,
+		statusLoading,
+		steps,
+		stopPending: stopMutation.isPending,
+		wsPort,
+		actions: {
+			applySetupCode: () => void applySetupCode(),
+			chooseInstallDir: () => void chooseInstallDir(),
+			copyInvite: () => inviteUrl && void copyText(inviteUrl, t("server.toast.inviteCopied")),
+			copySetupCode: () =>
+				friendSetupCode && void copyText(friendSetupCode, t("server.toast.setupCopied")),
+			detectIp: () => detectIpMutation.mutate(),
+			install: () => installMutation.mutate(false),
+			installBun: () => installBunMutation.mutate(),
+			openInvite: () => inviteUrl && void openUrl(inviteUrl),
+			openPortal: () => void openUrl(DISCORD_DEVELOPER_PORTAL_URL),
+			repair: () => installMutation.mutate(true),
+			restart: () => restartMutation.mutate(),
+			setAdministratorInvite: (value: boolean) => setField("administratorInvite", value),
+			setDiscordClientId: (value: string) => setField("discordClientId", value),
+			setDiscordToken: (value: string) => setField("discordToken", value),
+			setInstallDir,
+			setPort: (value: string) => setField("port", value),
+			setPublicWsUrl,
+			setSetupCode: (value: string) => setField("setupCode", value),
+			start: () => startMutation.mutate(),
+			stop: () => stopMutation.mutate(),
+		},
+	};
+}

--- a/app/src/windows/settings/pages/server.tsx
+++ b/app/src/windows/settings/pages/server.tsx
@@ -1,0 +1,99 @@
+import { useTranslation } from "react-i18next";
+import { DiscordSetupCard } from "@/windows/settings/components/server/discord-setup-card";
+import { ServerConfigCard } from "@/windows/settings/components/server/server-config-card";
+import { ServerConnectCard } from "@/windows/settings/components/server/server-connect-card";
+import { ServerHeader } from "@/windows/settings/components/server/server-header";
+import { ServerInstallCard } from "@/windows/settings/components/server/server-install-card";
+import { ServerLogsCard } from "@/windows/settings/components/server/server-logs-card";
+import { ServerProgressCard } from "@/windows/settings/components/server/server-progress-card";
+import { ServerRunCard } from "@/windows/settings/components/server/server-run-card";
+import { ServerShareCard } from "@/windows/settings/components/server/server-share-card";
+import { ServerStatusCard } from "@/windows/settings/components/server/server-status-card";
+import { useServerPage } from "@/windows/settings/hooks/use-server-page";
+
+export function ServerPage() {
+	const { t } = useTranslation();
+	const server = useServerPage();
+
+	return (
+		<div className="h-full overflow-y-auto p-5">
+			<div className="mx-auto flex max-w-6xl flex-col gap-5">
+				<ServerHeader status={server.status} progress={server.progress} />
+
+				<div className="grid gap-5 lg:grid-cols-[280px_minmax(0,1fr)]">
+					<div className="flex flex-col gap-3">
+						<ServerProgressCard title={t("server.progress")} steps={server.steps} />
+						<ServerStatusCard
+							status={server.status}
+							loading={server.statusLoading}
+							wsPort={server.wsPort}
+						/>
+					</div>
+
+					<div className="grid gap-5 xl:grid-cols-2">
+						<DiscordSetupCard
+							discordClientId={server.discordClientId}
+							discordToken={server.discordToken}
+							administratorInvite={server.administratorInvite}
+							inviteUrl={server.inviteUrl}
+							onDiscordClientIdChange={server.actions.setDiscordClientId}
+							onDiscordTokenChange={server.actions.setDiscordToken}
+							onAdministratorInviteChange={server.actions.setAdministratorInvite}
+							onOpenPortal={server.actions.openPortal}
+							onOpenInvite={server.actions.openInvite}
+							onCopyInvite={server.actions.copyInvite}
+						/>
+
+						<ServerConfigCard
+							installDir={server.installDir}
+							port={server.port}
+							publicWsUrl={server.publicWsUrl}
+							detectIpPending={server.detectIpPending}
+							onInstallDirChange={server.actions.setInstallDir}
+							onPortChange={server.actions.setPort}
+							onPublicWsUrlChange={server.actions.setPublicWsUrl}
+							onChooseInstallDir={server.actions.chooseInstallDir}
+							onDetectIp={server.actions.detectIp}
+						/>
+
+						<ServerInstallCard
+							status={server.status}
+							installDisabled={server.installDisabled}
+							installPending={server.installPending}
+							installBunPending={server.installBunPending}
+							onInstallBun={server.actions.installBun}
+							onInstall={server.actions.install}
+							onRepair={server.actions.repair}
+						/>
+
+						<ServerRunCard
+							status={server.status}
+							wsPort={server.wsPort}
+							startPending={server.startPending}
+							stopPending={server.stopPending}
+							restartPending={server.restartPending}
+							onStart={server.actions.start}
+							onStop={server.actions.stop}
+							onRestart={server.actions.restart}
+						/>
+
+						<ServerConnectCard
+							setupCode={server.setupCode}
+							onSetupCodeChange={server.actions.setSetupCode}
+							onApplySetupCode={server.actions.applySetupCode}
+						/>
+
+						<ServerShareCard
+							friendSetupCode={server.friendSetupCode}
+							onCopySetupCode={server.actions.copySetupCode}
+						/>
+
+						<div className="xl:col-span-2">
+							<ServerLogsCard logs={server.logs} loading={server.logsLoading} />
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memeover/bot",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"scripts": {
 		"dev": "bun run --watch src/index.ts",
 		"typecheck": "tsc --noEmit",

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "app": {
       "name": "@memeover/app",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@memeover/shared": "workspace:*",
         "@memeover/ui": "workspace:*",
@@ -20,6 +20,7 @@
         "@tanstack/react-router": "^1.170.10",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-autostart": "^2.5.1",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-store": "^2.4.3",
@@ -57,7 +58,7 @@
     },
     "bot": {
       "name": "@memeover/bot",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@logtail/pino": "^0.5.8",
         "@memeover/shared": "workspace:*",
@@ -106,7 +107,7 @@
     },
     "site": {
       "name": "@memeover/site",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@astrojs/react": "5.0.6",
         "@astrojs/sitemap": "3.7.3",
@@ -801,6 +802,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.2", "", { "os": "win32", "cpu": "x64" }, "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA=="],
 
     "@tauri-apps/plugin-autostart": ["@tauri-apps/plugin-autostart@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w=="],
+
+    "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck:app": "bun run --cwd app typecheck",
     "typecheck:shared": "bun run --cwd shared typecheck",
     "typecheck:ui": "bun run --cwd packages/ui typecheck",
-    "test": "bun test ./shared/src/setup-code.test.ts ./app/src/shared/settings.test.ts ./bot/src/commands/connection.test.ts ./bot/src/media/source.test.ts ./bot/src/media/dispatch.test.ts ./bot/src/utils/registry-state.test.ts"
+    "test": "bun test ./shared/src/setup-code.test.ts ./app/src/shared/settings.test.ts ./app/src/shared/server-creator.test.ts ./bot/src/commands/connection.test.ts ./bot/src/media/source.test.ts ./bot/src/media/dispatch.test.ts ./bot/src/utils/registry-state.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@memeover/site",
 	"type": "module",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"private": true,
 	"scripts": {
 		"dev": "astro dev",


### PR DESCRIPTION
Add a "Server" settings tab with a guided wizard so anyone can run their own MemeOver bot with their own Discord application:

- Discord app setup (token, client ID, minimal-permission invite link)
- One-click install: git clone + filtered bun install, .env generation
- Start/stop/restart with live logs (secrets redacted) and health polling
- Connection code import for the host, shareable friend code generation

Backend (Tauri):
- Heavy commands run via spawn_blocking to keep the UI responsive
- Managed bot process is killed on app exit (RunEvent::Exit)
- Bot entry file spawned directly so stop reaches the real process
- CREATE_NO_WINDOW on Windows; public IP detection via reqwest/rustls

Bump version to 1.4.0.