### PR TITLE
Fix legal links and start MemeOver in the tray on login

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@memeover/app",
 	"private": true,
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2144,7 +2144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memeover"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "objc2",
  "raw-window-handle",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memeover"
-version = "1.4.1"
+version = "1.4.2"
 description = "An overlay application that lets friends send memes to each other in real time from a Discord text channel."
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -4,8 +4,12 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     Emitter, Manager, WebviewUrl, WebviewWindowBuilder,
 };
+#[cfg(not(debug_assertions))]
+use tauri_plugin_autostart::ManagerExt as _;
 
 mod server_creator;
+
+const AUTOSTART_ARG: &str = "--autostart";
 
 // ─── Tray state ───────────────────────────────────────────────────────────────
 
@@ -14,6 +18,10 @@ mod server_creator;
 struct TrayState {
     show_item: Mutex<MenuItem<tauri::Wry>>,
     quit_item: Mutex<MenuItem<tauri::Wry>>,
+}
+
+fn launched_from_autostart() -> bool {
+    std::env::args_os().skip(1).any(|arg| arg == AUTOSTART_ARG)
 }
 
 // ─── Native overlay level (macOS) ─────────────────────────────────────────────
@@ -401,6 +409,16 @@ fn setup_overlay_close_notification(app: &tauri::App) {
 
 // ─── Tray icon ────────────────────────────────────────────────────────────────
 
+fn show_settings_window(app: &tauri::AppHandle) {
+    #[cfg(target_os = "macos")]
+    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+
+    if let Some(win) = app.get_webview_window("settings") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+}
+
 fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
     let show_i = MenuItem::with_id(app, "show", "Show MemeOver", true, None::<&str>)?;
     let hide_i = MenuItem::with_id(app, "hide", "Hide MemeOver", true, None::<&str>)?;
@@ -437,18 +455,14 @@ fn setup_tray(app: &tauri::App) -> tauri::Result<()> {
                     if win.is_visible().unwrap_or(false) {
                         let _ = win.hide();
                     } else {
-                        let _ = win.show();
-                        let _ = win.set_focus();
+                        show_settings_window(app);
                     }
                 }
             }
         })
         .on_menu_event(|app, event| match event.id.as_ref() {
             "show" => {
-                if let Some(w) = app.get_webview_window("settings") {
-                    let _ = w.show();
-                    let _ = w.set_focus();
-                }
+                show_settings_window(app);
             }
             "hide" => {
                 if let Some(w) = app.get_webview_window("settings") {
@@ -490,14 +504,11 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             // Focus the settings window of the already-running instance
-            if let Some(win) = app.get_webview_window("settings") {
-                let _ = win.show();
-                let _ = win.set_focus();
-            }
+            show_settings_window(app);
         }))
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
-            None,
+            Some(vec![AUTOSTART_ARG]),
         ))
         .invoke_handler(tauri::generate_handler![
             set_overlay_click_through,
@@ -517,6 +528,18 @@ pub fn run() {
             server_creator::server_creator_public_ip,
         ])
         .setup(|app| {
+            let background_start = launched_from_autostart();
+
+            #[cfg(not(debug_assertions))]
+            {
+                // Re-register existing entries so installs that enabled autostart
+                // before the background flag was introduced receive it as well.
+                let autolaunch = app.autolaunch();
+                if autolaunch.is_enabled().unwrap_or(false) {
+                    let _ = autolaunch.enable();
+                }
+            }
+
             create_overlay_window(&app.handle().clone())?;
 
             // Apply the native window level immediately after creation (prod only).
@@ -530,6 +553,13 @@ pub fn run() {
             setup_overlay_close_notification(app);
             setup_tray(app)?;
             setup_settings_close_behavior(app);
+
+            if background_start {
+                #[cfg(target_os = "macos")]
+                app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+            } else {
+                show_settings_window(app.handle());
+            }
 
             // Start the background watcher that reasserts the window level every 2 s.
             #[cfg(not(debug_assertions))]

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "minHeight": 560,
         "decorations": true,
         "resizable": true,
-        "visible": true
+        "visible": false
       }
     ],
     "security": {

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "memeover",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.simonhazard.memeover",
   "build": {
     "beforeDevCommand": "bun --bun run dev",

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -327,7 +327,7 @@
 	},
 	"settings": {
 		"autostart": "Launch at startup",
-		"autostart_hint": "Automatically launch MemeOver when the system starts."
+		"autostart_hint": "Automatically launch MemeOver in the system tray when you sign in."
 	},
 	"history": {
 		"title": "History",

--- a/app/src/i18n/locales/fr.json
+++ b/app/src/i18n/locales/fr.json
@@ -327,7 +327,7 @@
 	},
 	"settings": {
 		"autostart": "Lancer au démarrage",
-		"autostart_hint": "Lance MemeOver automatiquement au démarrage du système."
+		"autostart_hint": "Lance MemeOver dans la zone de notification à l’ouverture de session."
 	},
 	"history": {
 		"title": "Historique",

--- a/app/src/windows/settings/pages/about.tsx
+++ b/app/src/windows/settings/pages/about.tsx
@@ -15,24 +15,18 @@ import { LangToggle } from "@/windows/settings/components/lang-toggle";
 import { ThemeToggle } from "@/windows/settings/components/theme-toggle";
 import { UpdateChecker } from "@/windows/settings/components/update-checker";
 
+const LEGAL_URL = "https://memeover.simonhazard.com/legal/";
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function AboutPage() {
-	const { t, i18n } = useTranslation();
+	const { t } = useTranslation();
 
 	const { data: appVersion } = useQuery({
 		queryKey: ["app-version"],
 		queryFn: getVersion,
 		staleTime: Number.POSITIVE_INFINITY,
 	});
-
-	const isFrench = i18n.language.startsWith("fr");
-	const privacyUrl = isFrench
-		? "https://memeover.simonhazard.com/fr/confidentialite"
-		: "https://memeover.simonhazard.com/privacy";
-	const legalUrl = isFrench
-		? "https://memeover.simonhazard.com/fr/mentions-legales"
-		: "https://memeover.simonhazard.com/legal";
 
 	async function handleClearLocalHistory() {
 		try {
@@ -99,11 +93,11 @@ export function AboutPage() {
 								<li>{t("about.privacyHosted")}</li>
 							</ul>
 							<div className="flex flex-wrap gap-2">
-								<NbButton size="sm" variant="outline" onClick={() => openUrl(privacyUrl)}>
+								<NbButton size="sm" variant="outline" onClick={() => openUrl(LEGAL_URL)}>
 									<FileText className="size-3.5" aria-hidden="true" />
 									{t("about.privacyPolicy")}
 								</NbButton>
-								<NbButton size="sm" variant="outline" onClick={() => openUrl(legalUrl)}>
+								<NbButton size="sm" variant="outline" onClick={() => openUrl(LEGAL_URL)}>
 									<Scale className="size-3.5" aria-hidden="true" />
 									{t("about.legalNotice")}
 								</NbButton>


### PR DESCRIPTION
## Summary

- point the Privacy policy and Legal notice buttons to the canonical legal page
- register autostart launches with a dedicated `--autostart` argument
- create the settings window hidden and show it only for manual launches
- keep system-started sessions in the tray, including accessory mode on macOS
- restore and focus the settings window when the tray icon or menu is used
- refresh existing production autostart registrations so they receive the background flag

## Why

The in-app legal buttons referenced routes that no longer exist. In addition, the autostart integration launched MemeOver like a normal manual session because the application could not distinguish the two startup paths and the settings window was configured as visible.

## User impact

Legal and privacy links now open the expected page. Users who enable “Launch at startup” get a background session with only the tray icon; the main window opens when they click the tray icon.

## Validation

- `bun run check`
- `bun run typecheck`
- 42 Bun tests
- 7 Rust tests
- Cargo checks in debug and release profiles
- production Vite build

Closes #47
Closes #53
