### PR TITLE
Improve animation accessibility and polish

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@memeover/app",
 	"private": true,
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2144,7 +2144,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memeover"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "objc2",
  "raw-window-handle",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memeover"
-version = "1.4.2"
+version = "1.4.3"
 description = "An overlay application that lets friends send memes to each other in real time from a Discord text channel."
 authors = ["you"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "memeover",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "identifier": "com.simonhazard.memeover",
   "build": {
     "beforeDevCommand": "bun --bun run dev",

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -54,3 +54,42 @@
 [data-window="overlay"] img {
 	background: transparent !important;
 }
+
+/* ─── Overlay audio equalizer ─────────────────────────────────────────────── */
+
+.overlay-audio-equalizer-bar {
+	transform-origin: bottom;
+	animation-name: overlay-equalizer-pulse;
+	animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
+	animation-iteration-count: infinite;
+	animation-direction: alternate;
+}
+
+@keyframes overlay-equalizer-pulse {
+	from {
+		transform: scaleY(0.25);
+	}
+	to {
+		transform: scaleY(1);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.overlay-audio-equalizer-bar {
+		animation: none;
+	}
+
+	.overlay-audio-equalizer-bar:nth-child(1),
+	.overlay-audio-equalizer-bar:nth-child(5) {
+		transform: scaleY(0.4);
+	}
+
+	.overlay-audio-equalizer-bar:nth-child(2),
+	.overlay-audio-equalizer-bar:nth-child(4) {
+		transform: scaleY(0.7);
+	}
+
+	.overlay-audio-equalizer-bar:nth-child(3) {
+		transform: scaleY(1);
+	}
+}

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -1,7 +1,6 @@
 import { Toaster, type ToasterProps } from "@memeover/ui/components/ui/sonner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { createRootRoute, Outlet, useLocation } from "@tanstack/react-router";
-import { AnimatePresence, motion } from "framer-motion";
+import { createRootRoute, Outlet } from "@tanstack/react-router";
 import { ThemeProvider, useTheme } from "@/components/theme";
 import { TabNav } from "@/windows/settings/components/tab-nav";
 import appCss from "../App.css?url";
@@ -24,25 +23,15 @@ const queryClient = new QueryClient({
 // ─── Root layout ──────────────────────────────────────────────────────────────
 
 function RootLayout() {
-	const location = useLocation();
-
 	return (
 		<ThemeProvider>
 			<QueryClientProvider client={queryClient}>
 				<ThemedToaster richColors closeButton />
 				<main className="h-screen flex flex-col bg-background">
 					<TabNav />
-					<AnimatePresence initial={false}>
-						<motion.div
-							key={location.pathname}
-							initial={{ opacity: 0, y: 4 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.12, ease: "easeOut" }}
-							className="flex-1"
-						>
-							<Outlet />
-						</motion.div>
-					</AnimatePresence>
+					<div className="flex-1">
+						<Outlet />
+					</div>
 				</main>
 			</QueryClientProvider>
 		</ThemeProvider>

--- a/app/src/shared/reaction-budget.test.ts
+++ b/app/src/shared/reaction-budget.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import {
+	appendReactionWithinBudget,
+	getReactionCapacity,
+	REACTION_ANIMATION_COST,
+	REACTION_SCENE_BUDGET,
+} from "./reaction-budget";
+import {
+	FLOATING_REACTION_ANIMATIONS,
+	type FloatingReaction,
+	type FloatingReactionAnimation,
+} from "./types";
+
+function createReaction(id: string, animation: FloatingReactionAnimation): FloatingReaction {
+	return {
+		id,
+		emoji: "🎉",
+		leftPct: 50,
+		durationMs: 5000,
+		animation,
+		opacityPct: 100,
+		sizeVmin: 6,
+		fadeInPct: 10,
+		fadeOutPct: 80,
+		amplitudeVw: 8,
+		direction: 1,
+		rotationDeg: 12,
+	};
+}
+
+function appendBurst(reactions: FloatingReaction[]): FloatingReaction[] {
+	return reactions.reduce<FloatingReaction[]>(appendReactionWithinBudget, []);
+}
+
+function getSceneCost(reactions: readonly FloatingReaction[]): number {
+	return reactions.reduce(
+		(total, reaction) => total + REACTION_ANIMATION_COST[reaction.animation],
+		0,
+	);
+}
+
+describe("reaction complexity budget", () => {
+	test("retains the newest 30 straight reactions", () => {
+		const burst = Array.from({ length: 31 }, (_, index) =>
+			createReaction(`straight-${index + 1}`, "straight"),
+		);
+
+		const retained = appendBurst(burst);
+
+		expect(retained).toHaveLength(30);
+		expect(retained.map((reaction) => reaction.id)).toEqual(
+			burst.slice(1).map((reaction) => reaction.id),
+		);
+	});
+
+	test("limits fireworks to the scene budget", () => {
+		const burst = Array.from({ length: 13 }, (_, index) =>
+			createReaction(`firework-${index + 1}`, "firework"),
+		);
+
+		const retained = appendBurst(burst);
+
+		expect(retained).toHaveLength(12);
+		expect(retained.map((reaction) => reaction.id)).toEqual(
+			burst.slice(1).map((reaction) => reaction.id),
+		);
+		expect(getSceneCost(retained)).toBeLessThanOrEqual(REACTION_SCENE_BUDGET);
+	});
+
+	test("evicts the oldest mixed reactions and always admits the latest", () => {
+		const existing = [
+			...Array.from({ length: 20 }, (_, index) =>
+				createReaction(`straight-${index + 1}`, "straight"),
+			),
+			...Array.from({ length: 4 }, (_, index) =>
+				createReaction(`firework-${index + 1}`, "firework"),
+			),
+		];
+		const incoming = createReaction("latest", "pop");
+
+		const retained = appendReactionWithinBudget(existing, incoming);
+
+		expect(retained.map((reaction) => reaction.id)).toEqual([
+			...existing.slice(1).map((reaction) => reaction.id),
+			incoming.id,
+		]);
+		expect(retained[retained.length - 1]).toBe(incoming);
+		expect(getSceneCost(retained)).toBe(REACTION_SCENE_BUDGET);
+	});
+
+	test("does not mutate the input array", () => {
+		const first = createReaction("first", "straight");
+		const second = createReaction("second", "firework");
+		const existing = Object.freeze([first, second]);
+
+		const retained = appendReactionWithinBudget(existing, createReaction("latest", "pop"));
+
+		expect(existing).toEqual([first, second]);
+		expect(retained).not.toBe(existing);
+	});
+
+	test("defines an explicit cost and derived capacity for every preset", () => {
+		expect(Object.keys(REACTION_ANIMATION_COST).sort()).toEqual(
+			[...FLOATING_REACTION_ANIMATIONS].sort(),
+		);
+		expect(
+			Object.fromEntries(
+				FLOATING_REACTION_ANIMATIONS.map((animation) => [
+					animation,
+					getReactionCapacity(animation),
+				]),
+			),
+		).toEqual({
+			straight: 30,
+			serpentine: 20,
+			bounce: 20,
+			confetti: 20,
+			pop: 30,
+			firework: 12,
+		});
+	});
+});

--- a/app/src/shared/reaction-budget.ts
+++ b/app/src/shared/reaction-budget.ts
@@ -1,0 +1,42 @@
+import type { FloatingReaction, FloatingReactionAnimation } from "./types";
+
+export const MAX_REACTION_COUNT = 30;
+export const REACTION_SCENE_BUDGET = 60;
+
+export const REACTION_ANIMATION_COST = {
+	straight: 2,
+	pop: 2,
+	serpentine: 3,
+	bounce: 3,
+	confetti: 3,
+	firework: 5,
+} as const satisfies Record<FloatingReactionAnimation, number>;
+
+export function getReactionCapacity(animation: FloatingReactionAnimation): number {
+	return Math.min(
+		MAX_REACTION_COUNT,
+		Math.floor(REACTION_SCENE_BUDGET / REACTION_ANIMATION_COST[animation]),
+	);
+}
+
+export function appendReactionWithinBudget(
+	reactions: readonly FloatingReaction[],
+	incoming: FloatingReaction,
+): FloatingReaction[] {
+	const candidates = [...reactions, incoming];
+	let totalCost = candidates.reduce(
+		(sum, reaction) => sum + REACTION_ANIMATION_COST[reaction.animation],
+		0,
+	);
+	let firstRetainedIndex = 0;
+
+	while (
+		candidates.length - firstRetainedIndex > MAX_REACTION_COUNT ||
+		totalCost > REACTION_SCENE_BUDGET
+	) {
+		totalCost -= REACTION_ANIMATION_COST[candidates[firstRetainedIndex].animation];
+		firstRetainedIndex += 1;
+	}
+
+	return candidates.slice(firstRetainedIndex);
+}

--- a/app/src/shared/store.ts
+++ b/app/src/shared/store.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { create } from "zustand";
 import i18n from "@/i18n";
 import { restoreOverlayMonitor } from "./helpers";
+import { appendReactionWithinBudget } from "./reaction-budget";
 import { loadSettings } from "./settings";
 import type {
 	DisplayQueueItem,
@@ -17,9 +18,6 @@ import { DEFAULT_SETTINGS, FLOATING_REACTION_ANIMATIONS } from "./types";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const MAX_QUEUE_SIZE = 50;
-/** Hard cap on simultaneously animating reactions. FIFO eviction keeps the scene
- *  responsive during bursts while always admitting the most recent reaction. */
-const MAX_REACTIONS = 30;
 
 const REACTION_PRESET_TIMING: Record<
 	FloatingReactionAnimation,
@@ -140,11 +138,7 @@ export const useAppStore = create<AppStore>((set) => ({
 				direction,
 				rotationDeg: direction * (6 + Math.random() * 12),
 			};
-			const list =
-				state.reactions.length >= MAX_REACTIONS
-					? [...state.reactions.slice(1), reaction]
-					: [...state.reactions, reaction];
-			return { reactions: list };
+			return { reactions: appendReactionWithinBudget(state.reactions, reaction) };
 		}),
 	removeReaction: (id) =>
 		set((state) => ({ reactions: state.reactions.filter((r) => r.id !== id) })),

--- a/app/src/windows/overlay/components/audio-equalizer.tsx
+++ b/app/src/windows/overlay/components/audio-equalizer.tsx
@@ -1,13 +1,14 @@
 export function AudioEqualizer() {
 	const delays = ["0ms", "150ms", "75ms", "225ms", "30ms"];
+	const durations = ["560ms", "680ms", "520ms", "760ms", "620ms"];
 	return (
 		<div className="flex items-end justify-center gap-1 h-12">
 			{delays.map((delay, i) => (
 				<span
 					// biome-ignore lint/suspicious/noArrayIndexKey: Intended behavior
 					key={`equalizer-bar-${i}`}
-					className="inline-block w-2 rounded-sm bg-white animate-bounce"
-					style={{ height: "100%", animationDelay: delay, animationDuration: "600ms" }}
+					className="overlay-audio-equalizer-bar inline-block w-2 rounded-sm bg-white"
+					style={{ height: "100%", animationDelay: delay, animationDuration: durations[i] }}
 				/>
 			))}
 		</div>

--- a/app/src/windows/overlay/components/floating-reaction-animations.test.ts
+++ b/app/src/windows/overlay/components/floating-reaction-animations.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import type { FloatingReaction } from "@/shared/types";
+import { buildReactionKeyframes } from "./floating-reaction-animations";
+
+const reaction: FloatingReaction = {
+	id: "reaction-1",
+	emoji: "🎉",
+	leftPct: 50,
+	durationMs: 5000,
+	animation: "pop",
+	opacityPct: 72,
+	sizeVmin: 6,
+	fadeInPct: 15,
+	fadeOutPct: 80,
+	amplitudeVw: 8,
+	direction: 1,
+	rotationDeg: 24,
+};
+
+describe("buildReactionKeyframes", () => {
+	test("keeps reduced-motion reactions stationary while preserving their fade", () => {
+		const keyframes = buildReactionKeyframes(reaction, true);
+
+		expect(keyframes.initial.x).toBe("0vw");
+		expect(keyframes.initial.y).toBe("0vh");
+		expect(keyframes.initial.rotate).toBe(0);
+		expect(keyframes.animate.x).toEqual(["0vw", "0vw", "0vw", "0vw"]);
+		expect(keyframes.animate.y).toEqual(["0vh", "0vh", "0vh", "0vh"]);
+		expect(keyframes.animate.rotate).toEqual([0, 0, 0, 0]);
+		expect(keyframes.animate.opacity).toEqual([0, 0.72, 0.72, 0]);
+	});
+
+	test("preserves the normal pop preset's dramatic starting scale", () => {
+		const keyframes = buildReactionKeyframes(reaction, false);
+
+		expect(keyframes.initial.scale).toBe(0.35);
+	});
+});

--- a/app/src/windows/overlay/components/floating-reaction-animations.ts
+++ b/app/src/windows/overlay/components/floating-reaction-animations.ts
@@ -62,13 +62,13 @@ export function buildReactionKeyframes(
 	if (reduceMotion) {
 		const times = [0, fadeIn, fadeOut, 1];
 		return {
-			initial: { y: "0vh", opacity: 0, scale: 0.85 },
+			initial: { x: "0vw", y: "0vh", opacity: 0, rotate: 0, scale: 0.97 },
 			animate: {
 				x: ["0vw", "0vw", "0vw", "0vw"],
-				y: ["0vh", "-8vh", "-10vh", "-10vh"],
+				y: ["0vh", "0vh", "0vh", "0vh"],
 				opacity: [0, maxOpacity, maxOpacity, 0],
 				rotate: [0, 0, 0, 0],
-				scale: [0.85, 1, 1, 0.95],
+				scale: [0.97, 1, 1, 0.97],
 			},
 			transition: { duration, ease: "easeOut", times },
 		};

--- a/app/src/windows/overlay/components/media-popup.tsx
+++ b/app/src/windows/overlay/components/media-popup.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import type { DisplayQueueItem, OverlayPosition, Settings } from "@/shared/types";
 import { MediaDisplay } from "./media-display";
 
@@ -39,22 +39,26 @@ export function MediaPopup({
 	startTimer,
 	onMediaError,
 }: MediaPopupProps) {
+	const reduceMotion = useReducedMotion();
+
 	return (
 		<AnimatePresence mode="wait" onExitComplete={onExitComplete}>
 			{isVisible && current && (
 				<motion.div
 					key={current.queueId}
 					className={`fixed flex items-center justify-center ${POSITION_CLASSES[settings.position]}`}
-					initial={{ scale: 0.3, opacity: 0 }}
+					initial={{ scale: reduceMotion ? 1 : 0.3, opacity: 0 }}
 					animate={{
 						scale: 1,
 						opacity: 1,
-						transition: { duration: 0.22, ease: [0.22, 1, 0.36, 1] },
+						transition: reduceMotion
+							? { duration: 0.12, ease: [0.23, 1, 0.32, 1] }
+							: { type: "spring", duration: 0.28, bounce: 0.2 },
 					}}
 					exit={{
-						scale: 0.85,
+						scale: reduceMotion ? 1 : 0.96,
 						opacity: 0,
-						transition: { duration: 0.18, ease: "easeIn" },
+						transition: { duration: reduceMotion ? 0.12 : 0.13, ease: [0.23, 1, 0.32, 1] },
 					}}
 				>
 					{/* Inner wrapper applies the user offset without fighting the anchor's

--- a/app/src/windows/settings/components/color-picker.tsx
+++ b/app/src/windows/settings/components/color-picker.tsx
@@ -38,6 +38,8 @@ const SWATCH_LABELS: Record<SwatchColor, string> = {
 	"#FFFFFF": "Blanc",
 };
 
+const ICON_TRANSITION = { type: "spring", duration: 0.18, bounce: 0.1 } as const;
+
 function getContrastColor(hex: string): string {
 	const r = parseInt(hex.slice(1, 3), 16);
 	const g = parseInt(hex.slice(3, 5), 16);
@@ -48,8 +50,8 @@ function getContrastColor(hex: string): string {
 
 // Shared Neo-brutalist swatch button classes
 const swatchBase =
-	"relative rounded-sm border-2 border-foreground transition-all duration-150 hover:scale-110 hover:shadow-[2px_2px_0px_0px_var(--nb-shadow)] active:scale-95 active:shadow-none";
-const swatchSelected = "shadow-[2px_2px_0px_0px_var(--nb-shadow)] scale-105";
+	"relative rounded-sm border-2 border-foreground transition-[transform,box-shadow,border-color] duration-150 hover:scale-110 hover:shadow-[2px_2px_0px_0px_var(--nb-shadow)] active:scale-95 active:shadow-none";
+const swatchSelected = "shadow-[2px_2px_0px_0px_var(--nb-shadow)] scale-105 hover:scale-110";
 
 export interface ColorPickerProps {
 	value: string;
@@ -82,10 +84,10 @@ export function ColorPicker({ value, onChange, onReset }: ColorPickerProps) {
 										{isSelected && (
 											<motion.span
 												className="absolute inset-0 flex items-center justify-center"
-												initial={{ scale: 0 }}
-												animate={{ scale: 1 }}
-												exit={{ scale: 0 }}
-												transition={{ type: "spring", stiffness: 400, damping: 20 }}
+												initial={{ scale: 0.8, opacity: 0 }}
+												animate={{ scale: 1, opacity: 1 }}
+												exit={{ scale: 0.8, opacity: 0 }}
+												transition={ICON_TRANSITION}
 											>
 												<Check
 													className="size-3.5"
@@ -121,10 +123,10 @@ export function ColorPicker({ value, onChange, onReset }: ColorPickerProps) {
 									<motion.span
 										key="check"
 										className="absolute inset-0 flex items-center justify-center"
-										initial={{ scale: 0 }}
-										animate={{ scale: 1 }}
-										exit={{ scale: 0 }}
-										transition={{ type: "spring", stiffness: 400, damping: 20 }}
+										initial={{ scale: 0.8, opacity: 0 }}
+										animate={{ scale: 1, opacity: 1 }}
+										exit={{ scale: 0.8, opacity: 0 }}
+										transition={ICON_TRANSITION}
 									>
 										<Check
 											className="size-3.5"
@@ -135,10 +137,10 @@ export function ColorPicker({ value, onChange, onReset }: ColorPickerProps) {
 								) : (
 									<motion.span
 										key="palette"
-										initial={{ scale: 0 }}
-										animate={{ scale: 1 }}
-										exit={{ scale: 0 }}
-										transition={{ type: "spring", stiffness: 400, damping: 20 }}
+										initial={{ scale: 0.8, opacity: 0 }}
+										animate={{ scale: 1, opacity: 1 }}
+										exit={{ scale: 0.8, opacity: 0 }}
+										transition={ICON_TRANSITION}
 									>
 										<Palette className="size-3.5" />
 									</motion.span>

--- a/app/src/windows/settings/components/onboarding-wizard.tsx
+++ b/app/src/windows/settings/components/onboarding-wizard.tsx
@@ -3,8 +3,8 @@ import { NbCard } from "@memeover/ui/components/branded/nb-card";
 import { Progress } from "@memeover/ui/components/ui/progress";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { Variants } from "framer-motion";
-import { AnimatePresence, motion } from "framer-motion";
+import type { Transition, Variants } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { CheckCircle, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -24,20 +24,41 @@ interface OnboardingWizardProps {
 
 const TOTAL_STEPS = 3;
 
-const slideVariants: Variants = {
+const normalSlideVariants: Variants = {
 	enter: (d: number) => ({ x: d * 40, opacity: 0 }),
 	center: { x: 0, opacity: 1 },
 	exit: (d: number) => ({ x: d * -40, opacity: 0 }),
 };
 
-const fieldContainerVariants: Variants = {
+const reducedSlideVariants: Variants = {
+	enter: { opacity: 0 },
+	center: { opacity: 1 },
+	exit: { opacity: 0 },
+};
+
+const normalFieldContainerVariants: Variants = {
 	hidden: {},
 	visible: { transition: { staggerChildren: 0.07, delayChildren: 0.05 } },
 };
 
-const fieldVariants: Variants = {
+const reducedFieldContainerVariants: Variants = {
+	hidden: {},
+	visible: {},
+};
+
+const normalFieldVariants: Variants = {
 	hidden: { opacity: 0, y: 8 },
 	visible: { opacity: 1, y: 0, transition: { duration: 0.2, ease: "easeOut" } },
+};
+
+const reducedFieldVariants: Variants = {
+	hidden: { opacity: 0 },
+	visible: { opacity: 1, transition: { duration: 0.12, ease: [0.23, 1, 0.32, 1] } },
+};
+
+const reducedFadeTransition: Transition = {
+	duration: 0.12,
+	ease: [0.23, 1, 0.32, 1],
 };
 
 // ─── Wizard ───────────────────────────────────────────────────────────────────
@@ -45,6 +66,7 @@ const fieldVariants: Variants = {
 export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 	const { t } = useTranslation();
 	const queryClient = useQueryClient();
+	const reduceMotion = useReducedMotion() === true;
 
 	const [step, setStep] = useState(0);
 	const [direction, setDirection] = useState(1);
@@ -118,23 +140,26 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 					<motion.div
 						key={step}
 						custom={direction}
-						variants={slideVariants}
+						variants={reduceMotion ? reducedSlideVariants : normalSlideVariants}
 						initial="enter"
 						animate="center"
 						exit="exit"
-						transition={{ duration: 0.2, ease: "easeOut" }}
+						transition={reduceMotion ? reducedFadeTransition : { duration: 0.2, ease: "easeOut" }}
 					>
-						{step === 0 && <StepWelcome />}
+						{step === 0 && <StepWelcome reduceMotion={reduceMotion} />}
 
 						{step === 1 && (
-							<StepConnection>
+							<StepConnection reduceMotion={reduceMotion}>
 								<ConnectionCredentialsFields
 									form={form}
 									defaultWsUrl={DEFAULT_SETTINGS.wsUrl}
 									inputClassName="border-2 border-foreground/40 focus:border-foreground focus-visible:ring-2"
 									forceWsUrlVisible
 									renderFieldShell={(children) => (
-										<motion.div className="flex flex-col gap-2" variants={fieldVariants}>
+										<motion.div
+											className="flex flex-col gap-2"
+											variants={reduceMotion ? reducedFieldVariants : normalFieldVariants}
+										>
 											{children}
 										</motion.div>
 									)}
@@ -142,7 +167,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 							</StepConnection>
 						)}
 
-						{step === 2 && <StepDone />}
+						{step === 2 && <StepDone reduceMotion={reduceMotion} />}
 					</motion.div>
 				</AnimatePresence>
 
@@ -189,33 +214,39 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
 
 // ── StepWelcome ───────────────────────────────────────────────────────────────
 
-function StepWelcome() {
+function StepWelcome({ reduceMotion }: { reduceMotion: boolean }) {
 	const { t } = useTranslation();
 	return (
 		<NbCard>
 			<div className="space-y-3">
 				<motion.div
-					initial={{ rotate: -12, scale: 0 }}
-					animate={{ rotate: 0, scale: 1 }}
-					transition={{ type: "spring", stiffness: 400, damping: 20 }}
+					initial={reduceMotion ? { opacity: 0 } : { opacity: 0, rotate: -12, scale: 0.72 }}
+					animate={reduceMotion ? { opacity: 1 } : { opacity: 1, rotate: 0, scale: 1 }}
+					exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.8 }}
+					transition={
+						reduceMotion ? reducedFadeTransition : { type: "spring", duration: 0.3, bounce: 0.18 }
+					}
 					className="inline-block"
 				>
 					<Sparkles className="h-12 w-12 text-primary" aria-hidden="true" />
 				</motion.div>
 
 				<motion.h1
-					initial={{ opacity: 0, x: -10 }}
-					animate={{ opacity: 1, x: 0 }}
-					transition={{ duration: 0.25, ease: "easeOut" }}
+					initial={reduceMotion ? { opacity: 0 } : { opacity: 0, x: -10 }}
+					animate={reduceMotion ? { opacity: 1 } : { opacity: 1, x: 0 }}
+					transition={reduceMotion ? reducedFadeTransition : { duration: 0.25, ease: "easeOut" }}
 					className="font-display text-2xl tracking-wide"
 				>
 					{t("onboarding.step1_title")}
 				</motion.h1>
 
 				<motion.div
-					initial={{ scaleX: 0 }}
-					animate={{ scaleX: 1 }}
-					transition={{ duration: 0.25, ease: "easeOut", delay: 0.05 }}
+					initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scaleX: 0.75 }}
+					animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scaleX: 1 }}
+					exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scaleX: 0.8 }}
+					transition={
+						reduceMotion ? reducedFadeTransition : { duration: 0.25, ease: "easeOut", delay: 0.05 }
+					}
 					style={{ originX: 0 }}
 					className="bg-primary h-1.5 w-12 border border-foreground"
 				/>
@@ -223,7 +254,9 @@ function StepWelcome() {
 				<motion.p
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
-					transition={{ duration: 0.25, ease: "easeOut", delay: 0.1 }}
+					transition={
+						reduceMotion ? reducedFadeTransition : { duration: 0.25, ease: "easeOut", delay: 0.1 }
+					}
 					className="text-muted-foreground"
 				>
 					{t("onboarding.step1_desc")}
@@ -235,7 +268,13 @@ function StepWelcome() {
 
 // ── StepConnection ────────────────────────────────────────────────────────────
 
-function StepConnection({ children }: { children: React.ReactNode }) {
+function StepConnection({
+	children,
+	reduceMotion,
+}: {
+	children: React.ReactNode;
+	reduceMotion: boolean;
+}) {
 	const { t } = useTranslation();
 	return (
 		<NbCard>
@@ -246,7 +285,7 @@ function StepConnection({ children }: { children: React.ReactNode }) {
 				</div>
 				<motion.div
 					className="space-y-4"
-					variants={fieldContainerVariants}
+					variants={reduceMotion ? reducedFieldContainerVariants : normalFieldContainerVariants}
 					initial="hidden"
 					animate="visible"
 				>
@@ -265,16 +304,21 @@ const sparklePositions: { style: React.CSSProperties; delay: number }[] = [
 	{ style: { position: "absolute", top: "0px", left: "-8px" }, delay: 0.35 },
 ];
 
-function StepDone() {
+function StepDone({ reduceMotion }: { reduceMotion: boolean }) {
 	const { t } = useTranslation();
 	return (
 		<NbCard>
 			<div className="text-center space-y-3">
 				<div className="relative inline-block mx-auto">
 					<motion.div
-						initial={{ scale: 0 }}
-						animate={{ scale: [0, 1.1, 1] }}
-						transition={{ type: "spring", stiffness: 500, damping: 20 }}
+						initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}
+						animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+						exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.8 }}
+						transition={
+							reduceMotion
+								? reducedFadeTransition
+								: { type: "spring", duration: 0.36, bounce: 0.22 }
+						}
 					>
 						<CheckCircle className="h-12 w-12 text-primary" aria-hidden="true" />
 					</motion.div>
@@ -284,9 +328,10 @@ function StepDone() {
 							<motion.div
 								key={key}
 								style={style}
-								initial={{ opacity: 0, scale: 0 }}
-								animate={{ opacity: 1, scale: 1 }}
-								transition={{ delay, duration: 0.2 }}
+								initial={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }}
+								animate={reduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+								exit={reduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.8 }}
+								transition={reduceMotion ? reducedFadeTransition : { delay, duration: 0.2 }}
 							>
 								<Sparkles className="h-3 w-3 text-primary" />
 							</motion.div>
@@ -295,9 +340,11 @@ function StepDone() {
 				</div>
 
 				<motion.h2
-					initial={{ opacity: 0, x: -10 }}
-					animate={{ opacity: 1, x: 0 }}
-					transition={{ duration: 0.25, ease: "easeOut", delay: 0.1 }}
+					initial={reduceMotion ? { opacity: 0 } : { opacity: 0, x: -10 }}
+					animate={reduceMotion ? { opacity: 1 } : { opacity: 1, x: 0 }}
+					transition={
+						reduceMotion ? reducedFadeTransition : { duration: 0.25, ease: "easeOut", delay: 0.1 }
+					}
 					className="text-xl font-display tracking-wide"
 				>
 					{t("onboarding.step3_title")}

--- a/app/src/windows/settings/components/tab-nav.tsx
+++ b/app/src/windows/settings/components/tab-nav.tsx
@@ -51,7 +51,7 @@ export function TabNav() {
 							size="sm"
 							onClick={() => navigate({ to: tab.route })}
 							className={cn(
-								"relative h-8 gap-1.5 rounded-lg text-sm font-display tracking-wide border-2 transition-all cursor-pointer",
+								"relative h-8 gap-1.5 rounded-lg text-sm font-display tracking-wide border-2 transition-[color,background-color,border-color,transform,box-shadow] duration-150 cursor-pointer",
 								isActive
 									? `bg-primary-400 text-primary-foreground border-foreground ${NB_SHADOW_SM} hover:bg-primary-400 hover:text-primary-foreground dark:hover:bg-primary-400 -translate-x-px -translate-y-px`
 									: "bg-transparent text-muted-foreground border-transparent hover:text-foreground hover:bg-accent",
@@ -61,7 +61,10 @@ export function TabNav() {
 							<span>{t(tab.labelKey)}</span>
 							{showUpdateDot && (
 								<span className="pointer-events-none absolute -top-1 -right-1 flex size-2.5">
-									<span className="absolute inline-flex h-full w-full rounded-full bg-secondary-500 opacity-75 animate-ping" />
+									<span
+										className="absolute inline-flex h-full w-full rounded-full bg-secondary-500 opacity-75 animate-ping"
+										style={{ animationIterationCount: 2 }}
+									/>
 									<span className="relative inline-flex size-2.5 rounded-full bg-secondary-500 border border-foreground" />
 								</span>
 							)}

--- a/app/src/windows/settings/components/update-checker.tsx
+++ b/app/src/windows/settings/components/update-checker.tsx
@@ -59,18 +59,13 @@ function VersionChip({
 	label,
 	version,
 	highlight = false,
-	delay = 0,
 }: {
 	label: string;
 	version: string;
 	highlight?: boolean;
-	delay?: number;
 }) {
 	return (
-		<motion.div
-			initial={{ opacity: 0, y: 6 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={{ delay, duration: 0.25, ease: "easeOut" }}
+		<div
 			className={cn(
 				"flex-1 border-2 border-foreground p-3 text-center",
 				highlight && `bg-primary/5 ${NB_SHADOW_SM}`,
@@ -82,7 +77,7 @@ function VersionChip({
 			<p className={cn("font-display text-xl tracking-wide", highlight && "text-primary")}>
 				v{version}
 			</p>
-		</motion.div>
+		</div>
 	);
 }
 
@@ -115,25 +110,16 @@ function UpdateDialogContent({
 
 			{/* Version comparison */}
 			<div className="flex items-center gap-3">
-				<VersionChip label={t("updater.currentLabel")} version={meta.currentVersion} delay={0} />
-				<motion.div
-					initial={{ opacity: 0, x: -6 }}
-					animate={{ opacity: 1, x: 0 }}
-					transition={{ delay: 0.1, duration: 0.2 }}
-				>
+				<VersionChip label={t("updater.currentLabel")} version={meta.currentVersion} />
+				<div>
 					<ArrowRight className="size-4 text-muted-foreground shrink-0" aria-hidden="true" />
-				</motion.div>
-				<VersionChip label={t("updater.newLabel")} version={meta.version} highlight delay={0.08} />
+				</div>
+				<VersionChip label={t("updater.newLabel")} version={meta.version} highlight />
 			</div>
 
 			{/* Changelog */}
 			{meta.body && (
-				<motion.div
-					initial={{ opacity: 0 }}
-					animate={{ opacity: 1 }}
-					transition={{ delay: 0.15, duration: 0.3 }}
-					className="space-y-2"
-				>
+				<div className="space-y-2">
 					<p className="text-xs uppercase tracking-widest text-muted-foreground font-display">
 						{t("updater.changelog")}
 					</p>
@@ -142,7 +128,7 @@ function UpdateDialogContent({
 							<Markdown components={markdownComponents}>{meta.body}</Markdown>
 						</ScrollArea>
 					</div>
-				</motion.div>
+				</div>
 			)}
 
 			{/* Download progress */}

--- a/app/src/windows/settings/components/user-count-indicator.tsx
+++ b/app/src/windows/settings/components/user-count-indicator.tsx
@@ -1,4 +1,4 @@
-import { NB_HOVER_SHADOW_LG, NB_SHADOW_MD } from "@memeover/ui/lib/nb-classes";
+import { NB_SHADOW_MD } from "@memeover/ui/lib/nb-classes";
 import { cn } from "@memeover/ui/lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { Users } from "lucide-react";
@@ -37,10 +37,6 @@ export function UserCountIndicator({ wsStatus }: UserCountIndicatorProps) {
 				// Neo-brutalist borders & shadow
 				"border-2 border-foreground",
 				NB_SHADOW_MD,
-				// Hover micro-interaction — badge lifts and shadow extends
-				"transition-all duration-100 ease-out",
-				"hover:-translate-x-px hover:-translate-y-px",
-				NB_HOVER_SHADOW_LG,
 				// State-driven background
 				liveState === "active" && "bg-emerald-400 text-black",
 				liveState === "alone" && "bg-amber-300 text-black",
@@ -49,12 +45,6 @@ export function UserCountIndicator({ wsStatus }: UserCountIndicatorProps) {
 		>
 			{/* ── Live dot ── */}
 			<span className="relative flex h-2 w-2 shrink-0" aria-hidden="true">
-				{liveState === "active" && (
-					<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-700 opacity-60" />
-				)}
-				{liveState === "alone" && (
-					<span className="absolute inline-flex h-full w-full animate-pulse rounded-full bg-amber-600 opacity-60" />
-				)}
 				<span
 					className={cn(
 						"relative inline-flex h-2 w-2 rounded-full",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck:app": "bun run --cwd app typecheck",
     "typecheck:shared": "bun run --cwd shared typecheck",
     "typecheck:ui": "bun run --cwd packages/ui typecheck",
-    "test": "bun test ./shared/src/setup-code.test.ts ./app/src/shared/settings.test.ts ./app/src/shared/server-creator.test.ts ./app/src/windows/overlay/components/floating-reaction-animations.test.ts ./bot/src/commands/connection.test.ts ./bot/src/media/source.test.ts ./bot/src/media/dispatch.test.ts ./bot/src/utils/discord-intents.test.ts ./bot/src/utils/registry-state.test.ts"
+    "test": "bun test ./shared/src/setup-code.test.ts ./app/src/shared/settings.test.ts ./app/src/shared/reaction-budget.test.ts ./app/src/shared/server-creator.test.ts ./app/src/windows/overlay/components/floating-reaction-animations.test.ts ./bot/src/commands/connection.test.ts ./bot/src/media/source.test.ts ./bot/src/media/dispatch.test.ts ./bot/src/utils/discord-intents.test.ts ./bot/src/utils/registry-state.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck:app": "bun run --cwd app typecheck",
     "typecheck:shared": "bun run --cwd shared typecheck",
     "typecheck:ui": "bun run --cwd packages/ui typecheck",
-    "test": "bun test ./shared/src/setup-code.test.ts ./app/src/shared/settings.test.ts ./app/src/shared/server-creator.test.ts ./bot/src/commands/connection.test.ts ./bot/src/media/source.test.ts ./bot/src/media/dispatch.test.ts ./bot/src/utils/discord-intents.test.ts ./bot/src/utils/registry-state.test.ts"
+    "test": "bun test ./shared/src/setup-code.test.ts ./app/src/shared/settings.test.ts ./app/src/shared/server-creator.test.ts ./app/src/windows/overlay/components/floating-reaction-animations.test.ts ./bot/src/commands/connection.test.ts ./bot/src/media/source.test.ts ./bot/src/media/dispatch.test.ts ./bot/src/utils/discord-intents.test.ts ./bot/src/utils/registry-state.test.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@memeover/ui/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform,opacity] duration-150 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 	{
 		variants: {
 			variant: {

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -15,7 +15,7 @@ function Switch({
 			data-slot="switch"
 			data-size={size}
 			className={cn(
-				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-[background-color,border-color,box-shadow,opacity] duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -6,13 +6,15 @@ import type * as React from "react";
 import { cn } from "@memeover/ui/lib/utils";
 
 function TooltipProvider({
-	delayDuration = 0,
+	delayDuration = 325,
+	skipDelayDuration = 100,
 	...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
 	return (
 		<TooltipPrimitive.Provider
 			data-slot="tooltip-provider"
 			delayDuration={delayDuration}
+			skipDelayDuration={skipDelayDuration}
 			{...props}
 		/>
 	);
@@ -38,7 +40,7 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+					"bg-foreground text-background animate-in fade-in-0 zoom-in-97 animation-duration-130 ease-[cubic-bezier(0.23,1,0.32,1)] data-[state=instant-open]:animation-duration-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-97 data-[state=closed]:animation-duration-125 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
 					className,
 				)}
 				{...props}

--- a/packages/ui/src/lib/nb-classes.ts
+++ b/packages/ui/src/lib/nb-classes.ts
@@ -24,7 +24,7 @@ export const NB_BTN_BASE = [
 	"border-2 border-foreground",
 	NB_SHADOW_SM,
 	"active:shadow-none active:translate-x-0.5 active:translate-y-0.5",
-	"transition-all font-display tracking-wide",
+	"transition-[color,background-color,border-color,box-shadow,transform,opacity] duration-150 font-display tracking-wide",
 ].join(" ");
 
 /** Small button — NB_BTN_BASE + text-xs */
@@ -35,7 +35,7 @@ export const NB_BTN_LG = [
 	"border-2 border-foreground",
 	NB_SHADOW_MD,
 	"active:shadow-none active:translate-x-0.75 active:translate-y-0.75",
-	"transition-all font-display tracking-wide",
+	"transition-[color,background-color,border-color,box-shadow,transform,opacity] duration-150 font-display tracking-wide",
 ].join(" ");
 
 /** Disabled state — combine with any NB_BTN_* */
@@ -53,7 +53,7 @@ export const NB_TOGGLE_ITEM = [
 	// Full static string — never `data-[state=on]:${NB_SHADOW_SM}` (breaks Tailwind scanner)
 	"data-[state=on]:shadow-[2px_2px_0px_0px_var(--nb-shadow)]",
 	"hover:bg-primary-400/15 hover:border-foreground/60",
-	"transition-all font-display text-xs tracking-wide",
+	"transition-[color,background-color,border-color,box-shadow,transform,opacity] duration-150 font-display text-xs tracking-wide",
 ].join(" ");
 
 /** Toggle — similar to ToggleGroupItem but with hover states */
@@ -64,7 +64,7 @@ export const NB_TOGGLE = [
 	// Full static string — never `data-[state=on]:${NB_SHADOW_SM}` (breaks Tailwind scanner)
 	"data-[state=on]:shadow-[2px_2px_0px_0px_var(--nb-shadow)]",
 	"hover:bg-primary-400/15 hover:border-foreground/60",
-	"transition-all",
+	"transition-[color,background-color,border-color,box-shadow,transform,opacity] duration-150",
 ].join(" ");
 
 // ─── Card classes ────────────────────────────────────────────────────────────

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@memeover/site",
 	"type": "module",
-	"version": "1.4.1",
+	"version": "1.4.3",
 	"private": true,
 	"scripts": {
 		"dev": "astro dev",

--- a/site/src/components/open-source-section.astro
+++ b/site/src/components/open-source-section.astro
@@ -1,5 +1,5 @@
 ---
-import { Bug, GitFork } from "lucide-react";
+import { Bug, Coffee, GitFork } from "lucide-react";
 import type { Locale } from "@/i18n";
 import { getTranslations } from "@/i18n";
 
@@ -41,6 +41,15 @@ const dict = getTranslations(lang);
 			>
 				<Bug className="size-5" aria-hidden="true" />
 				{dict.openSource.reportBug}
+			</a>
+			<a
+				href="https://ko-fi.com/simonhazard"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-primary text-primary-foreground font-display tracking-wide text-base border-2 border-foreground shadow-[3px_3px_0px_0px_var(--nb-shadow)] transition-[box-shadow,transform,background-color] duration-200 hover:bg-primary-500 hover:shadow-[4px_4px_0px_0px_var(--nb-shadow)] active:shadow-none active:translate-x-0.75 active:translate-y-0.75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+			>
+				<Coffee className="size-5" aria-hidden="true" />
+				{dict.openSource.supportOnKofi}
 			</a>
 		</div>
 	</div>

--- a/site/src/i18n/en.ts
+++ b/site/src/i18n/en.ts
@@ -159,6 +159,7 @@ export const en = {
 			"MemeOver is open source under the MIT license. You can inspect it, host it yourself, report issues and shape what comes next.",
 		viewOnGithub: "View on GitHub",
 		reportBug: "Report a bug",
+		supportOnKofi: "Support on Ko-fi",
 		contribute:
 			"Fork the repo, open a PR — every contribution matters. Check out the issues for ideas!",
 	},

--- a/site/src/i18n/fr.ts
+++ b/site/src/i18n/fr.ts
@@ -164,6 +164,7 @@ export const fr: Translations = {
 			"MemeOver est open source sous licence MIT. Tu peux l'inspecter, l'auto-héberger, signaler des problèmes et aider à choisir la suite.",
 		viewOnGithub: "Voir sur GitHub",
 		reportBug: "Signaler un bug",
+		supportOnKofi: "Soutenir sur Ko-fi",
 		contribute:
 			"Fork le repo, ouvre une PR — chaque contribution compte. Jette un œil aux issues pour des idées !",
 	},


### PR DESCRIPTION
## Summary

- preserve the overlay's expressive media and reaction motion while adding complete reduced-motion paths for media, reactions, the audio equalizer, and onboarding
- calm routine settings motion, narrow shared control transitions, improve tooltip timing, and simplify update-dialog information staging
- add a typed complexity budget for reaction bursts with immutable FIFO admission and focused tests
- bump the desktop application version to 1.4.3

## Why

The overlay should remain surprising and playful, while routine settings interactions should feel immediate and restrained. Users who request reduced motion now get stationary or fade-only alternatives, and expensive reaction presets can no longer overwhelm the scene as easily during bursts.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run test` — 49 tests passed
- `bun run --cwd app build`
- `bun run build:site`
- `cargo check --manifest-path app/src-tauri/Cargo.toml`
- `cargo test --manifest-path app/src-tauri/Cargo.toml` — 7 tests passed
- manual animation QA in normal and reduced-motion modes confirmed by the operator

## Follow-up

Production FPS and long-frame measurements for maximum straight, mixed, and firework bursts remain a separate performance-validation follow-up. This PR intentionally does not rewrite the reaction renderer without measured evidence.
